### PR TITLE
Adds support for showPreview flag

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -6,6 +6,7 @@ import { css } from 'emotion';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
 import { headline } from '@guardian/src-foundations/typography';
+import { renderHtmlDocument } from './utils/renderHtmlDocument';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -22,7 +23,12 @@ const ExampleComponent: React.FC<{}> = () => (
 
 app.get('/', (req, res) => {
     const { html, css } = extractCritical(renderToStaticMarkup(<ExampleComponent />));
-    res.send({ html, css });
+    if (typeof req.query.showPreview !== 'undefined') {
+        const htmlContent = renderHtmlDocument({ html, css });
+        res.send(htmlContent);
+    } else {
+        res.send({ html, css });
+    }
 });
 
 // If local then don't wrap in serverless

--- a/src/utils/renderHtmlDocument.ts
+++ b/src/utils/renderHtmlDocument.ts
@@ -11,7 +11,6 @@ export const renderHtmlDocument = ({ html, css }: TemplateData) =>
         <title>Contributions Service Preview</title>
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <!-- <link rel="stylesheet" href="css/normalize.css" /> -->
         <style>
           ${css}
         </style>

--- a/src/utils/renderHtmlDocument.ts
+++ b/src/utils/renderHtmlDocument.ts
@@ -1,0 +1,25 @@
+interface TemplateData {
+    html: string;
+    css: string;
+}
+
+export const renderHtmlDocument = ({ html, css }: TemplateData) =>
+    `<!DOCTYPE html>
+    <html lang="en-GB">
+      <head>
+        <meta charset="utf-8" />
+        <title>Contributions Service Preview</title>
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <!-- <link rel="stylesheet" href="css/normalize.css" /> -->
+        <style>
+          ${css}
+        </style>
+      </head>
+      <body>
+        <div style="width: 1200px; margin: 0 auto;">
+          ${html}
+        </div>
+      </body>
+    </html>
+    `;


### PR DESCRIPTION
# What does this PR change?
Adds support for a `showPreview` parameter to be set in the request URL, indicating the user expects the response data (i.e. `{html, css}`) to be rendered and served inside a basic HTML document for previewing purposes.

# Notes
The `showPreview` URL parameter is optional and doesn't require any value, neither does it check for one. Not setting the parameter will result in the default behaviour of serving a JSON response.