### PR TITLE
Extend Preview Template

### DIFF
--- a/src/utils/renderHtmlDocument.ts
+++ b/src/utils/renderHtmlDocument.ts
@@ -1,3 +1,5 @@
+const CDNFontPath = 'https://assets.guim.co.uk/static/frontend';
+
 interface TemplateData {
     html: string;
     css: string;
@@ -12,11 +14,110 @@ export const renderHtmlDocument = ({ html, css }: TemplateData) =>
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <style>
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff) format("woff");
+                font-weight: 300;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff) format("woff");
+                font-weight: 300;
+                font-style: italic;
+            }
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff) format("woff");
+                font-weight: 500;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff) format("woff");
+                font-weight: 500;
+                font-style: italic;
+            }
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff) format("woff");
+                font-weight: 700;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GH Guardian Headline";
+                src: url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff) format("woff");
+                font-weight: 700;
+                font-style: italic;
+            }
+            @font-face {
+                font-family: "GuardianTextEgyptian";
+                src: url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff) format("woff");
+                font-weight: 400;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GuardianTextEgyptian";
+                src: url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff) format("woff");
+                font-weight: 400;
+                font-style: italic;
+            }
+            @font-face {
+                font-family: "GuardianTextEgyptian";
+                src: url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularBold.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularBold.woff) format("woff");
+                font-weight: 700;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GuardianTextSans";
+                src: url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff) format("woff");
+                font-weight: 400;
+                font-style: normal;
+            }
+            @font-face {
+                font-family: "GuardianTextSans";
+                src: url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff) format("woff");
+                font-weight: 400;
+                font-style: italic;
+            }
+            @font-face {
+                font-family: "GuardianTextSans";
+                src: url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff) format("woff");
+                font-weight: 700;
+                font-style: normal;
+            }
+        </style>
+        <style>
+            html {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+            }
+            body {
+                margin: 0;
+            }
+            .preview-wrapper {
+                max-width: 1200px;
+                margin: 0 auto;
+            }
+        </style>
+        <style>
           ${css}
         </style>
       </head>
       <body>
-        <div style="width: 1200px; margin: 0 auto;">
+        <div class="preview-wrapper">
           ${html}
         </div>
       </body>

--- a/src/utils/renderHtmlDocument.ts
+++ b/src/utils/renderHtmlDocument.ts
@@ -108,7 +108,7 @@ export const renderHtmlDocument = ({ html, css }: TemplateData) =>
                 margin: 0;
             }
             .preview-wrapper {
-                max-width: 1200px;
+                max-width: 1300px;
                 margin: 0 auto;
             }
         </style>


### PR DESCRIPTION
# What does this PR to?
Extends the Preview Template to include the Guardian font faces and some basic CSS resets.

# Motivation
We've realised we'll most definitely need the Guardian font faces to be added to the document, and we're confident we have some very basic CSS resets already in place across Frontend and DCR.