### PR TITLE
DefaultEpic component

### DIFF
--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'emotion';
 import { textSans } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-foundations/mq';
 
 const link = css`
     background: ${palette.brandYellow.main};
@@ -11,15 +10,11 @@ const link = css`
     color: ${palette.neutral[7]};
     ${textSans.medium({ fontWeight: 'bold' })};
     text-decoration: none;
-    padding: 12px 21px;
+    padding: 12px 35px 12px 21px;
     line-height: 18px;
     position: relative;
-    margin-right: 10px;
+    margin: 4px 10px 4px 0;
     transition: background-color 0.3s ease-in-out;
-
-    ${from.mobileMedium} {
-        padding-right: 35px;
-    }
 
     :hover {
         background: ${palette.brandYellow.dark};
@@ -34,10 +29,6 @@ const link = css`
         width: 32px;
         transform: translate(0, -50%);
         transition: transform 0.3s ease-in-out;
-
-        ${until.mobileMedium} {
-            display: none;
-        }
     }
 
     :hover svg {

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { css } from 'emotion';
+import { textSans } from '@guardian/src-foundations/typography';
+import { palette } from '@guardian/src-foundations';
+// import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
+import { from, until } from '@guardian/src-foundations/mq';
+
+const link = css`
+    background: ${palette.brandYellow.main};
+    border-radius: 16px;
+    box-sizing: border-box;
+    color: ${palette.neutral[7]};
+    float: left;
+    ${textSans.small()};
+    font-weight: 700;
+    height: 32px;
+    text-decoration: none;
+    padding: 6px 12px 0 12px;
+    line-height: 18px;
+    position: relative;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    ${from.mobileMedium} {
+        padding-right: 34px;
+    }
+
+    svg {
+        fill: currentColor;
+        position: absolute;
+        right: 3px;
+        top: 50%;
+        height: 32px;
+        width: 32px;
+        transform: translate(0, -50%);
+        transition: transform 0.3s ease-in-out;
+
+        ${until.mobileMedium} {
+            display: none;
+        }
+    }
+
+    :hover svg {
+        transform: translate(3px, -50%);
+    }
+`;
+
+export const RRButton: React.FC<{
+    url: string;
+    dataLinkNamePrefix: string;
+    dataLinkNameSuffix: string;
+    linkText: string;
+}> = ({ url, dataLinkNamePrefix, dataLinkNameSuffix, linkText }) => {
+    return (
+        <a
+            className={link}
+            href={url}
+            data-link-name={`${dataLinkNamePrefix}${dataLinkNameSuffix}`}
+        >
+            {linkText}
+            {/* {linkText} <ArrowRightIcon /> */}
+        </a>
+    );
+};

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -10,7 +10,7 @@ const link = css`
     color: ${palette.neutral[7]};
     ${textSans.medium({ fontWeight: 'bold' })};
     text-decoration: none;
-    padding: 12px 35px 12px 21px;
+    padding: 12px 46px 12px 21px;
     line-height: 18px;
     position: relative;
     margin: 4px 10px 4px 0;
@@ -23,10 +23,10 @@ const link = css`
     svg {
         fill: currentColor;
         position: absolute;
-        right: 3px;
+        right: 12px;
         top: 50%;
-        height: 32px;
-        width: 32px;
+        height: 30px;
+        width: 30px;
         transform: translate(0, -50%);
         transition: transform 0.3s ease-in-out;
     }
@@ -41,10 +41,10 @@ export const CallToAction: React.FC<{
     linkText: string;
 }> = ({ url, linkText }) => {
     return (
-        <a className={link} href={url}>
+        <a className={link} href={url} target="_blank">
             {linkText}
-            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
-                <path d="M22.8 14.6l-7.6-7.6-.7.7 5.5 6.6h-14v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9" />
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <path d="M22.8 14.6l-7.6-7.6-.7.7 5.5 6.6h-14v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
             </svg>
         </a>
     );

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { css } from 'emotion';
 import { textSans } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 
+// Spacing values below are multiples of 4.
+// See https://www.theguardian.design/2a1e5182b/p/449bd5
 const link = css`
     background: ${palette.brandYellow.main};
     border-radius: 21px;
@@ -10,10 +13,10 @@ const link = css`
     color: ${palette.neutral[7]};
     ${textSans.medium({ fontWeight: 'bold' })};
     text-decoration: none;
-    padding: 12px 46px 12px 21px;
+    padding: ${space[3]}px ${space[12]}px ${space[3]}px ${space[5]}px;
     line-height: 18px;
     position: relative;
-    margin: 4px 10px 4px 0;
+    margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
     transition: background-color 0.3s ease-in-out;
 
     :hover {

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -2,27 +2,27 @@ import React from 'react';
 import { css } from 'emotion';
 import { textSans } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
-// import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { from, until } from '@guardian/src-foundations/mq';
 
 const link = css`
     background: ${palette.brandYellow.main};
-    border-radius: 16px;
+    border-radius: 21px;
     box-sizing: border-box;
     color: ${palette.neutral[7]};
-    float: left;
-    ${textSans.small()};
-    font-weight: 700;
-    height: 32px;
+    ${textSans.medium({ fontWeight: 'bold' })};
     text-decoration: none;
-    padding: 6px 12px 0 12px;
+    padding: 12px 21px;
     line-height: 18px;
     position: relative;
     margin-right: 10px;
-    margin-bottom: 6px;
+    transition: background-color 0.3s ease-in-out;
 
     ${from.mobileMedium} {
-        padding-right: 34px;
+        padding-right: 35px;
+    }
+
+    :hover {
+        background: ${palette.brandYellow.dark};
     }
 
     svg {
@@ -45,20 +45,16 @@ const link = css`
     }
 `;
 
-export const RRButton: React.FC<{
+export const CallToAction: React.FC<{
     url: string;
-    dataLinkNamePrefix: string;
-    dataLinkNameSuffix: string;
     linkText: string;
-}> = ({ url, dataLinkNamePrefix, dataLinkNameSuffix, linkText }) => {
+}> = ({ url, linkText }) => {
     return (
-        <a
-            className={link}
-            href={url}
-            data-link-name={`${dataLinkNamePrefix}${dataLinkNameSuffix}`}
-        >
+        <a className={link} href={url}>
             {linkText}
-            {/* {linkText} <ArrowRightIcon /> */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
+                <path d="M22.8 14.6l-7.6-7.6-.7.7 5.5 6.6h-14v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9" />
+            </svg>
         </a>
     );
 };

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { titlepiece } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
+import { CallToAction } from './CallToAction';
 
 const wrapperStyles = css`
     margin-top: 24px;
@@ -64,6 +65,12 @@ export const DefaultEpic: React.FC<{}> = ({}) => {
                 </strong>
             </p>
             <div className={buttonWrapperStyles}>
+                <CallToAction
+                    url=""
+                    dataLinkNamePrefix={dataLinkNamePrefix}
+                    dataLinkNameSuffix="contribute-cta"
+                    linkText="Support The Guardian"
+                />
                 <img
                     src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
                     alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { titlepiece } from '@guardian/src-foundations/typography';
+import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { CallToAction } from './CallToAction';
 
@@ -12,15 +12,22 @@ const wrapperStyles = css`
 `;
 
 const headingStyles = css`
-    ${titlepiece.small()}
+    ${headline.xxsmall({ fontWeight: 'bold' })}
+    margin-top: 0;
     margin-bottom: 12px;
 `;
 
 const bodyStyles = css`
     margin: 0 auto 8px;
+    ${body.medium({ lineHeight: 'regular' })};
+`;
+
+const highlightWrapperStyles = css`
+    ${body.medium({ fontWeight: 'bold' })}
 `;
 
 const highlightStyles = css`
+    padding: 2px;
     background-color: ${palette.brandYellow.main};
 `;
 
@@ -28,9 +35,13 @@ const buttonWrapperStyles = css`
     margin-top: 24px;
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
 `;
 
-const imageStyles = css``;
+const imageStyles = css`
+    width: auto;
+    height: 25px;
+`;
 
 export const DefaultEpic: React.FC<{}> = ({}) => {
     return (
@@ -59,16 +70,16 @@ export const DefaultEpic: React.FC<{}> = ({}) => {
                 We hope you will consider supporting us today. We need your support to keep
                 delivering quality journalism that’s open and independent. Every reader
                 contribution, however big or small, is so valuable.{' '}
-                <strong className={highlightStyles}>
-                    Support The Guardian from as little as £1 - and it only takes a minute. Thank
-                    you.
+                <strong className={highlightWrapperStyles}>
+                    <span className={highlightStyles}>
+                        Support The Guardian from as little as £1 - and it only takes a minute.
+                        Thank you.
+                    </span>
                 </strong>
             </p>
             <div className={buttonWrapperStyles}>
                 <CallToAction
-                    url=""
-                    dataLinkNamePrefix={dataLinkNamePrefix}
-                    dataLinkNameSuffix="contribute-cta"
+                    url="https://support.theguardian.com/uk/contribute"
                     linkText="Support The Guardian"
                 />
                 <img

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -9,6 +9,15 @@ const wrapperStyles = css`
     padding: 4px 5px 12px;
     border-top: 1px solid ${palette.brandYellow.main};
     background-color: ${palette.neutral[97]};
+
+    * {
+        ::selection {
+            background: ${palette.brandYellow.main};
+        }
+        ::-moz-selection {
+            background: ${palette.brandYellow.main};
+        }
+    }
 `;
 
 const headingStyles = css`

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 import { CallToAction } from './CallToAction';
 
+// Spacing values below are multiples of 4.
+// See https://www.theguardian.design/2a1e5182b/p/449bd5
 const wrapperStyles = css`
-    margin-top: 24px;
-    padding: 4px 5px 12px;
+    margin-top: ${space[6]}px;
+    padding: ${space[1]}px ${space[1]}px ${space[3]}px;
     border-top: 1px solid ${palette.brandYellow.main};
     background-color: ${palette.neutral[97]};
 
@@ -23,11 +26,11 @@ const wrapperStyles = css`
 const headingStyles = css`
     ${headline.xxsmall({ fontWeight: 'bold' })}
     margin-top: 0;
-    margin-bottom: 12px;
+    margin-bottom: ${space[3]}px;
 `;
 
 const bodyStyles = css`
-    margin: 0 auto 8px;
+    margin: 0 auto ${space[2]}px;
     ${body.medium()};
 `;
 
@@ -41,7 +44,7 @@ const highlightStyles = css`
 `;
 
 const buttonWrapperStyles = css`
-    margin: 24px 10px 4px 0;
+    margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -51,7 +54,7 @@ const imageStyles = css`
     display: inline-block;
     width: auto;
     height: 25px;
-    margin: 4px 0;
+    margin: ${space[1]}px 0;
 `;
 
 export const DefaultEpic: React.FC<{}> = ({}) => {

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { css } from 'emotion';
+import { titlepiece } from '@guardian/src-foundations/typography';
+import { palette } from '@guardian/src-foundations';
+
+const wrapperStyles = css`
+    margin-top: 24px;
+    padding: 4px 5px 12px;
+    border-top: 1px solid ${palette.brandYellow.main};
+    background-color: ${palette.neutral[97]};
+`;
+
+const headingStyles = css`
+    ${titlepiece.small()}
+    margin-bottom: 12px;
+`;
+
+const bodyStyles = css`
+    margin: 0 auto 8px;
+`;
+
+const highlightStyles = css`
+    background-color: ${palette.brandYellow.main};
+`;
+
+const buttonWrapperStyles = css`
+    margin-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+`;
+
+const imageStyles = css``;
+
+export const DefaultEpic: React.FC<{}> = ({}) => {
+    return (
+        <section className={wrapperStyles}>
+            <h2 className={headingStyles}>Since you're here...</h2>
+            <p className={bodyStyles}>
+                ... we have a small favour to ask. More people, like you, are reading and supporting
+                the Guardian’s independent, investigative journalism than ever before. And unlike
+                many news organisations, we made the choice to keep our reporting open for all,
+                regardless of where they live or what they can afford to pay.
+            </p>
+            <p className={bodyStyles}>
+                The Guardian will engage with the most critical issues of our time – from the
+                escalating climate catastrophe to widespread inequality to the influence of big tech
+                on our lives. At a time when factual information is a necessity, we believe that
+                each of us, around the world, deserves access to accurate reporting with integrity
+                at its heart.
+            </p>
+            <p className={bodyStyles}>
+                Our editorial independence means we set our own agenda and voice our own opinions.
+                Guardian journalism is free from commercial and political bias and not influenced by
+                billionaire owners or shareholders. This means we can give a voice to those less
+                heard, explore where others turn away, and rigorously challenge those in power.
+            </p>
+            <p className={bodyStyles}>
+                We hope you will consider supporting us today. We need your support to keep
+                delivering quality journalism that’s open and independent. Every reader
+                contribution, however big or small, is so valuable.{' '}
+                <strong className={highlightStyles}>
+                    Support The Guardian from as little as £1 - and it only takes a minute. Thank
+                    you.
+                </strong>
+            </p>
+            <div className={buttonWrapperStyles}>
+                <img
+                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    className={imageStyles}
+                />
+            </div>
+        </section>
+    );
+};

--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -19,7 +19,7 @@ const headingStyles = css`
 
 const bodyStyles = css`
     margin: 0 auto 8px;
-    ${body.medium({ lineHeight: 'regular' })};
+    ${body.medium()};
 `;
 
 const highlightWrapperStyles = css`
@@ -32,15 +32,17 @@ const highlightStyles = css`
 `;
 
 const buttonWrapperStyles = css`
-    margin-top: 24px;
+    margin: 24px 10px 4px 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
 `;
 
 const imageStyles = css`
+    display: inline-block;
     width: auto;
     height: 25px;
+    margin: 4px 0;
 `;
 
 export const DefaultEpic: React.FC<{}> = ({}) => {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -2,27 +2,16 @@ import express from 'express';
 import awsServerlessExpress from 'aws-serverless-express';
 import { Context } from 'aws-lambda';
 import React from 'react';
-import { css } from 'emotion';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
-import { headline } from '@guardian/src-foundations/typography';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
+import { DefaultEpic } from './components/DefaultEpic';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
 
-const ExampleComponent: React.FC<{}> = () => (
-    <h1
-        className={css`
-            ${headline.medium()}
-        `}
-    >
-        Hello World
-    </h1>
-);
-
 app.get('/', (req, res) => {
-    const { html, css } = extractCritical(renderToStaticMarkup(<ExampleComponent />));
+    const { html, css } = extractCritical(renderToStaticMarkup(<DefaultEpic />));
     if (typeof req.query.showPreview !== 'undefined') {
         const htmlContent = renderHtmlDocument({ html, css });
         res.send(htmlContent);

--- a/src/utils/renderHtmlDocument.ts
+++ b/src/utils/renderHtmlDocument.ts
@@ -72,8 +72,8 @@ export const renderHtmlDocument = ({ html, css }: TemplateData) =>
             }
             @font-face {
                 font-family: "GuardianTextEgyptian";
-                src: url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularBold.woff2) format("woff2"),
-                    url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularBold.woff) format("woff");
+                src: url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2) format("woff2"),
+                    url(${CDNFontPath}/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff) format("woff");
                 font-weight: 700;
                 font-style: normal;
             }


### PR DESCRIPTION
# What does this PR do?
Adds a `DefaultEpic` component and serves it through the root endpoint. It's been styled for visual parity with Frontend, although making use of @guardian/src-foundations.

# Why?
Because we want to serve the default epic through our service.

# Link to Trello card
https://trello.com/c/ibvNCUWr/13-implement-the-default-epic-component-in-new-service

# Screenshot
![Screenshot 2020-01-17 at 17 41 52](https://user-images.githubusercontent.com/1692169/72633601-b7ada980-3950-11ea-8039-bf9e5d0a2e62.png)
