### PR TITLE
Remove default RR option

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,6 @@ deployments:
         type: aws-lambda
         dependencies: [cloudformation]
         parameters:
-            prefixStack: true
             bucket: aws-frontend-contributions-service
             fileName: lambda.zip
             functionNames: [-contributions-service-]


### PR DESCRIPTION
RR complains if you provide a parameter with a default value set. This is unfortunate, but the warnings are sufficiently annoying that we should 'fix' them.

<img width="628" alt="Screenshot 2020-01-20 at 13 20 54" src="https://user-images.githubusercontent.com/858402/72729711-bf0ac800-3b87-11ea-927c-746c638ac59c.png">
<img width="1151" alt="Screenshot 2020-01-20 at 13 21 08" src="https://user-images.githubusercontent.com/858402/72729736-d0ec6b00-3b87-11ea-8554-9a26baa6daa5.png">

