### PR TITLE
Removes outer container top margin

### DIFF
--- a/src/components/DefaultEpic.tsx
+++ b/src/components/DefaultEpic.tsx
@@ -8,7 +8,6 @@ import { CallToAction } from './CallToAction';
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
 const wrapperStyles = css`
-    margin-top: ${space[6]}px;
     padding: ${space[1]}px ${space[1]}px ${space[3]}px;
     border-top: 1px solid ${palette.brandYellow.main};
     background-color: ${palette.neutral[97]};


### PR DESCRIPTION
Quick fix to remove the top margin from the DefaultEpic component; the motivation for this is the belief the outer margins should be controlled by the platform making use of our service, rather than out service (or the components we serve) imposing any spacing rules between themselves and the other components on the platform.