### PR TITLE
Lazily fetch default epic content

### DIFF
--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -9,7 +9,9 @@ export type DefaultEpicContent = {
     highlighted: string[];
 };
 
-export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => {
+let epicContent: Promise<DefaultEpicContent> | undefined;
+
+const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicContent> => {
     const response = await fetch(defaultEpicUrl);
     if (!response.ok) {
         throw new Error(
@@ -31,4 +33,12 @@ export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => 
         },
         { paragraphs: [], highlighted: [] },
     );
+};
+
+export const fetchDefaultEpicContent = (): Promise<DefaultEpicContent> => {
+    if (epicContent) return epicContent;
+
+    epicContent = fetchDefaultEpicContentWithoutCaching();
+
+    return epicContent;
 };

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -5,19 +5,24 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
-import { fetchDefaultEpicContent, DefaultEpicContent } from './api/contributionsApi';
+import { fetchDefaultEpicContent } from './api/contributionsApi';
 import { DefaultEpic } from './components/DefaultEpic';
 import cors from 'cors';
 
-const bootApp = (content: DefaultEpicContent): void => {
-    const app = express();
-    app.use(express.json({ limit: '50mb' }));
+// Pre-cache API response
+fetchDefaultEpicContent();
 
-    // Note allows *all* cors. We may want to tighten this later.
-    app.use(cors());
-    app.options('*', cors());
+const app = express();
+app.use(express.json({ limit: '50mb' }));
 
-    app.get('/', (req, res) => {
+// Note allows *all* cors. We may want to tighten this later.
+app.use(cors());
+app.options('*', cors());
+
+app.get('/', async (req, res) => {
+    try {
+        const content = await fetchDefaultEpicContent();
+
         const { html, css } = extractCritical(
             renderToStaticMarkup(
                 <DefaultEpic
@@ -33,20 +38,19 @@ const bootApp = (content: DefaultEpicContent): void => {
         } else {
             res.send({ html, css });
         }
-    });
-
-    // If local then don't wrap in serverless
-    const PORT = process.env.PORT || 3030;
-    if (process.env.NODE_ENV === 'development') {
-        app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
-    } else {
-        const server = awsServerlessExpress.createServer(app);
-        exports.handler = (event: any, context: Context) => {
-            awsServerlessExpress.proxy(server, event, context);
-        };
+    } catch (error) {
+        console.log('Something went wrong: ', error.message);
+        res.status(500).send({ error: error.message });
     }
-};
+});
 
-fetchDefaultEpicContent()
-    .then(bootApp)
-    .catch(error => console.error(`App failed to boot: ${error}`));
+// If local then don't wrap in serverless
+const PORT = process.env.PORT || 3030;
+if (process.env.NODE_ENV === 'development') {
+    app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+} else {
+    const server = awsServerlessExpress.createServer(app);
+    exports.handler = (event: any, context: Context) => {
+        awsServerlessExpress.proxy(server, event, context);
+    };
+}


### PR DESCRIPTION
This PR changes the way we fetch the default epic. Previously we were fetching at boot time (asynchronously) and then starting the app. This approach caused issues when deploying, I think around the fact that the `exports.handler` call was happening asynchronously. I looked into Amazon's docs but didn't quite find an approach that worked. So instead we're now lazily fetching the epic content when the request comes in (and caching the response), which simplifies the server.

Note that I've added a line to the server to kick off the async default epic request immediately, which should reduce the waiting time for the first request. However given that we're not really performance concerned at this point, maybe that's adding unnecessary complexity. Thoughts welcome!