### PR TITLE
Adds config object to urlencoded Express middleware

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -21,7 +21,7 @@ fetchDefaultEpicContent();
 
 // Use middleware
 const app = express();
-app.use(express.urlencoded());
+app.use(express.urlencoded({ extended: true }));
 app.use(express.json({ limit: '50mb' }));
 
 // Note allows *all* cors. We may want to tighten this later.


### PR DESCRIPTION
## What?
Passes a config object to the `urlencoded()` middleware function in Express with the `extended: true` flag.

## Why?
Because this option is now required and omitting it results in a console warning.

## Notes
https://stackoverflow.com/questions/29960764/what-does-extended-mean-in-express-4-0