### PR TITLE
API Gateway - use HTTP rather than REST

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "postbuild": "./bin/package.sh",
     "upload-artifact": "node-riffraff-artifact",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "cdk": "cdk"
   },
   "dependencies": {
     "@guardian/src-foundations": "^0.11.0",
@@ -32,17 +33,18 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigateway": "^1.21.0",
-    "@aws-cdk/aws-lambda": "^1.21.0",
-    "@aws-cdk/core": "^1.21.0",
+    "@aws-cdk/aws-apigateway": "^1.22.0",
+    "@aws-cdk/aws-apigatewayv2": "^1.22.0",
+    "@aws-cdk/aws-lambda": "^1.22.0",
+    "@aws-cdk/core": "^1.22.0",
     "@babel/core": "^7.8.3",
     "@guardian/node-riffraff-artifact": "^0.1.1",
     "@storybook/addon-actions": "^5.3.8",
+    "@storybook/addon-knobs": "^5.3.8",
     "@storybook/addon-links": "^5.3.8",
     "@storybook/addons": "^5.3.8",
-    "@storybook/react": "^5.3.8",
-    "@storybook/addon-knobs": "^5.3.8",
     "@storybook/preset-typescript": "^1.2.0",
+    "@storybook/react": "^5.3.8",
     "@types/aws-serverless-express": "^3.3.2",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.1",
@@ -53,7 +55,7 @@
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
-    "aws-cdk": "^1.21.0",
+    "aws-cdk": "^1.22.0",
     "aws-sdk": "^2.604.0",
     "babel-loader": "^8.0.6",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,230 +2,237 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assets@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.21.0.tgz#7703bfa34e43e356f044bc86c5e37f9cf99006c1"
-  integrity sha512-SHI5MAP/ZOR1MOjrU+AhlEos+pYKQl5lLuh7LzCqkBZFV1STKWZz19OQl5vu2NI6CU0eu5HU48EdRIWx0CsNbA==
+"@aws-cdk/assets@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.22.0.tgz#49e114a365a82c61e7252c9b3e2b22eaf4372a10"
+  integrity sha512-IIu96KjoYPtMwPPfM1qF/o0e89hN5/Aa5Jlpu1vQyAFD9S/CkLe000gXKPuc//PmbCEnEqoWSECTAb44dkMjdA==
   dependencies:
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-apigateway@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.21.0.tgz#faceb697862b4a52073ffe2c2a35899ebfae86f0"
-  integrity sha512-gzY0OTmVVA30yhwx90CXYkqHU4vusZ45fJLCpLQc4W0HL4wv11w9nOeYl2BxqK9YPdZ9tUlT2X/z+nUrQk/V9A==
+"@aws-cdk/aws-apigateway@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.22.0.tgz#a22c428dc5c2ffca522c9794acc41724151afdae"
+  integrity sha512-N+SNi4ruUHh7QeDaeuQscwBe88LFtsKfitYAgWwxZdDXMUbKw/Bz3u8mHjmvQTcMnJ2sFn7wbRvy3Gj/aEdZJw==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.21.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-lambda" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-certificatemanager" "1.22.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-lambda" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-certificatemanager@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.21.0.tgz#868c72650074e5a556a26ddee5f464b12aef61c3"
-  integrity sha512-2E2dDofeUn1e5/UK7ttsQtcjr2ZV30c1Yy7bGHxZXSen4SBgsgvEKeX4X2ToNOItmQ0UNbrK1XsJx1cv9xyQkw==
+"@aws-cdk/aws-apigatewayv2@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.22.0.tgz#a9dbc40a6f7de809165e571a85bc485b2b32a78c"
+  integrity sha512-3zTVFLdXbpUCZdSiYIaMQSqPyhKtNJCFBkj/iBmZnPSsGSg4lLfRfTVnTkg45D7YQ6k140V5hwgSaQ9Er7r+6A==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-lambda" "1.21.0"
-    "@aws-cdk/aws-route53" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-cloudformation@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.21.0.tgz#68fb8addd9b186ba149de4e9f57b5133a4bfb1a7"
-  integrity sha512-/J6YvCW6de3Q7sPY1mzTd5P7b6Su2mEZZqCuKMuFQ5YUmllN1cSlLMtkZi+R0+4hi2M/Nsu0Z+oHZtZ8IZ0VQw==
+"@aws-cdk/aws-certificatemanager@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.22.0.tgz#2bff88824eaf782c8b6bd3c5e0f716aafa513413"
+  integrity sha512-0sKB0e8E8AmiYHVgVzRjGkywG91P6Eikk6wUcYz/aZQS4E9UlMhy5AtWpwZ9VljcULslgtwP6ckackAR9c5vQQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-lambda" "1.21.0"
-    "@aws-cdk/aws-s3" "1.21.0"
-    "@aws-cdk/aws-sns" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-cloudformation" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-lambda" "1.22.0"
+    "@aws-cdk/aws-route53" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-cloudwatch@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.21.0.tgz#fb14de613950c7658f6a86a210ad5ebe12ff9a39"
-  integrity sha512-pw0R1eVLtMGkHViK2pYqo0DX5RmcxxykRWCoE+gIy6JcC/FXEvyE50QXIJeI4H4/xw3ycF6TdnbX7VHaMlAjOg==
+"@aws-cdk/aws-cloudformation@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.22.0.tgz#a53d8f1d8c2cb98538b7a65848e2bd27abf43f3d"
+  integrity sha512-v1zG3AUWR97u8i98WU44Ytm2tWkJspxzPe/uf6NOYlpWfz0jfyB3wSgGCjG2Vo4kKc4CzmSrCblKNbQMPhGqfA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-lambda" "1.22.0"
+    "@aws-cdk/aws-s3" "1.22.0"
+    "@aws-cdk/aws-sns" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/aws-ec2@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.21.0.tgz#057492ce6e2a1bd5776d440f9b608693b4b5176c"
-  integrity sha512-yFJDhxAD6UsO6ZVPg46FWQ/r+vrQodaheXFetutqUtqUAXJg/T5F1/32oLD3/esv26FN06lJYvMnh+aPOI8k3w==
+"@aws-cdk/aws-cloudwatch@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.22.0.tgz#545cd14bd734caf08640dac4cfad5e1dcbd73a47"
+  integrity sha512-Lgd3C8XuST2ApNRoXIIYGszjXHZKByFYI5/Nynkimw10fYksiMxDb4TjN2lzHWFFZeXqJlZL9kUIiEtyiZPDpg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-ssm" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.21.0.tgz#59de4a6ea382f6dbb04ba8fef996e6dc9029fac0"
-  integrity sha512-4n90nSTBsuH70z6v4DEJkNROIzlokbKb+1YvVeOKG/A9gUEGSgsrP7u5J+SIsRbi9ZP1qLTs6QJzl4i4UfPWJA==
+"@aws-cdk/aws-ec2@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.22.0.tgz#d09dd428faa8a47ad3040118a7f92b1225c4bf32"
+  integrity sha512-N05VOmT7/v0YcziPRyl9EHdQzmo12hcm/1RAe/i7j4ZGrxuupBPY4LLHIrv+91k+Rd2zq8W1HyHbJx45U2iTxg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.21.0"
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-ec2" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-lambda" "1.21.0"
-    "@aws-cdk/aws-s3" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-ssm" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/aws-events@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.21.0.tgz#46f56df465f0ff81ccff9eb02ed3b25f181a02f0"
-  integrity sha512-mhswo/7b5ER7y67op6irFAozf0v3/k+/9QGjc2DrboFoCkWmm0ahy+3FpkJhD0+n5j8YkBOgsgdg7Iam49ouJA==
+"@aws-cdk/aws-elasticloadbalancingv2@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.22.0.tgz#368778fb01b846b7fc91fc98ce53c4fc5658bc9f"
+  integrity sha512-0ICrLl2bzpbK41UqeNqme2cGJ84o50oimqgxxpPEnyblzLwsKToHR2hk/SMrFyRG78WCtFY1NDvHF2YHp/SzKA==
   dependencies:
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-certificatemanager" "1.22.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-ec2" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-lambda" "1.22.0"
+    "@aws-cdk/aws-s3" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-iam@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.21.0.tgz#d697187cefb7ebf82d55acf4249afe587cfaab07"
-  integrity sha512-WyAWyKPHWSv324EF068HPj2pPYq7EY15jnalIpVRrWLJ6rZhPqwzhQgc0RhgWNd8+e8QFFZCY7KWzDYV7AAz5g==
+"@aws-cdk/aws-events@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.22.0.tgz#632907c7f65d56c22e72f0020e16815f48537021"
+  integrity sha512-Ow0rys5s24/03RDCeP1LIiGYf0dkhsEy6lLNCSnBiF1FldnkpOflbsMkOe/mBqUDCmFHHeU7SxmIRTsgd6wI1g==
   dependencies:
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/region-info" "1.21.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-kms@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.21.0.tgz#6cb63f73a1d2a2315591b9b2d3400b93b88135a2"
-  integrity sha512-pwR05bTycdiq/6J4YAAIWFr8XhD/e588bpxdcSgCcGeJGdiUpZ5Fq5nS6TY6HGNMAS/aazyHRkK13vSN2HXyPw==
+"@aws-cdk/aws-iam@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.22.0.tgz#5b83bf01f5c9b52b7e202a1fe1c116777dcbde8a"
+  integrity sha512-5XNxgGmK3RVGfHbsTGGz6lN8F+jzHzIODIl4PTQwnBOfDRQ/kB/HI3bs0JnG2Se6I1PtU0ARuCj4GTU2OTvjhw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/region-info" "1.22.0"
 
-"@aws-cdk/aws-lambda@1.21.0", "@aws-cdk/aws-lambda@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.21.0.tgz#84f49c49c952a244d80dccd6d0bc54352fdf4dff"
-  integrity sha512-SIhQPQa8CRL+V97pPhR6B5A+47no6X9N1CAxYdQsdYuzruaabKepuZaxLXC4cuYiU910LxM0Sb+iACzeJ8Vn9w==
+"@aws-cdk/aws-kms@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.22.0.tgz#70ad52592a1a9990fbcf2af010c249f1b7bd83a7"
+  integrity sha512-bkFMkp6I609O4x6AKHz4B8DK6zvRvbNCrKRIiNvFfibuN66ncgLeVjQXGfe51Nc3fSW8Xxa1cXyBuo24EiSq7A==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-ec2" "1.21.0"
-    "@aws-cdk/aws-events" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-logs" "1.21.0"
-    "@aws-cdk/aws-s3" "1.21.0"
-    "@aws-cdk/aws-s3-assets" "1.21.0"
-    "@aws-cdk/aws-sqs" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-logs@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.21.0.tgz#35e2e63c33b34c4543b987c8c0156791f827cf1f"
-  integrity sha512-DcRHNGaIUO1Obx+zqYWoslQvt7YFYCzWxH+UcRv1J/ZNaWou2tbGmv98i6+0CR4kUEENgCT0nLoHG89xb2fR3g==
+"@aws-cdk/aws-lambda@1.22.0", "@aws-cdk/aws-lambda@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.22.0.tgz#1f1d13a2c9b56bf3bb672a415d7011022d8aff76"
+  integrity sha512-YIWy/52htcsK2tbeT0bcovwRU90+aH3BpqIfus7WF02csmn8J5i5n1oshOl+l8uG2gD3MtSZQXmIuxcJ0HsYkw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-ec2" "1.22.0"
+    "@aws-cdk/aws-events" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-logs" "1.22.0"
+    "@aws-cdk/aws-s3" "1.22.0"
+    "@aws-cdk/aws-s3-assets" "1.22.0"
+    "@aws-cdk/aws-sqs" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/aws-route53@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.21.0.tgz#2e73aee03b22209a0a8a30711774b2167098b766"
-  integrity sha512-pUALeNYp11suS/ofb1pAqet26MlE8Oxkj5h8DnnUDrhWWew1q27m0PB11lJaARehWLU6wNP04hayapJKFkh6zg==
+"@aws-cdk/aws-logs@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.22.0.tgz#651ba257279ede92d0a3def8a2c4d2a99b852ab8"
+  integrity sha512-IYg2Ll0B7eL5m6KhyPwcNl8413nmFWFFcEcTpPVRJpNWm7NdRMyDVX+XFteJJToYaGUDHdj1UiegOthxWYbgdA==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.21.0"
-    "@aws-cdk/aws-logs" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-s3-assets@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.21.0.tgz#7d040aa5aec97b6d4cb09348a3c40f599d0b279c"
-  integrity sha512-120+w3tlpvq5Ff9XhpTiBpNxf04dnRzBdkT4u/ZTmMfB7m2R1Z4KCf3dQ5lgPj8vyJsDJDyPIDnE7wVj6E9t7Q==
+"@aws-cdk/aws-route53@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.22.0.tgz#18e5df9e8e4e22607b14431e4f1b0718b4908042"
+  integrity sha512-h8BCEJNubp4kzJWyiTYOIltY/rke7dzR5XttwgPJ1GuaMG4CRLwhAjHDAse0bVbfcWqbodthO6tv5uJgSdQULA==
   dependencies:
-    "@aws-cdk/assets" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-s3" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-ec2" "1.22.0"
+    "@aws-cdk/aws-logs" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/aws-s3@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.21.0.tgz#7b428bd610cb6b2ad6bdc24a402733ee2dbc4446"
-  integrity sha512-IolXDpxFFqEmkez/djSaSS1BvM+O4NuQLY6TAi3GO81oDcl1AsrpIBLSaISKejT8qf5Tg0m3Q0CvhcBDsJXqgg==
+"@aws-cdk/aws-s3-assets@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.22.0.tgz#6bee78d4deb1d3b69f5bb722f431b7158ab017ae"
+  integrity sha512-uj3sOe0Mq4I20Cli38gUeaH3iF1Wq3/DXetyhsbH+rmr/SfqFUhR8MpdTDYpMb1jUCw5/bfLDj9s4rEfvE0+zg==
   dependencies:
-    "@aws-cdk/aws-events" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-kms" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/assets" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-s3" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/aws-sns@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.21.0.tgz#dd7732566b5abbe950eabbd129f156c0f88cf7b1"
-  integrity sha512-6rW+W8ENaA41BDG3bmS205+Y6SaA7cYHuxorgpMrEL3WviD/ro312p8s0yK6KlH41HYEEx490iQURVvZz//vyQ==
+"@aws-cdk/aws-s3@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.22.0.tgz#a6d01791799fdca99ef90f401e8303550cd467f3"
+  integrity sha512-yGWVowtM+eq/dvgYQZXnrI9ap6vSpPsADT+PpBqFeyb8ch9Knfye22ZZZiKKbaQpkAvqN5SdzMI9veWOMQ4Fgg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-events" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-kms" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-events" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-kms" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-sqs@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.21.0.tgz#48f6c64b2130b584c04798b8d93aecd01acf72f3"
-  integrity sha512-HNybRL7wt116WZUPXTptstwSQeSUZlva6uNs1WX8I4y1aqxT7qzcm3X0TQIHmbyVCaM++NaCqwx3Xh0Q536U6w==
+"@aws-cdk/aws-sns@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.22.0.tgz#4bcf70181d4a58aa0e7b7380387edb0bce824d80"
+  integrity sha512-ECb9lgF7iobxCndNdDD0p8GJHsXn0dqHH+pObHMF+uhVU4vhkb232pcs6LGK7RLq8Fo7L4/exTOQo/BQyKutpA==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.21.0"
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-kms" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-events" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-kms" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/aws-ssm@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.21.0.tgz#0635971e6ac40f8e043aec60e4839e69f3501452"
-  integrity sha512-dsSxoyZ4JlFkfGZxsumgJiiUe3ifUOzSirDSGOtfyxK4N6qtyH/AUMsDm7+hXmpFaFBrxNMv7VvZdO/2DjVxYg==
+"@aws-cdk/aws-sqs@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.22.0.tgz#62d5c9dd5f57307985eca310ad82b02a7e091791"
+  integrity sha512-sv14TN1OaC0SkekxrLh2p8Z4uqCRauZiJklG+0Tb+VUHCPZQTCUiyMlkKk2fOhOBU9zQC+MAo4O0Ck25n8Zh9Q==
   dependencies:
-    "@aws-cdk/aws-iam" "1.21.0"
-    "@aws-cdk/aws-kms" "1.21.0"
-    "@aws-cdk/core" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/aws-cloudwatch" "1.22.0"
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-kms" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
 
-"@aws-cdk/cfnspec@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.21.0.tgz#87f57f16560f4560aad3db81ad018d4190d702bd"
-  integrity sha512-YNdIYHuFWlOxqeqRglPcSPEBRtA3S0v1dLP1HwHF8n/P9q6g922//uFyfdT3zTTiv2uZClq0my7Kl/6yVMscJw==
+"@aws-cdk/aws-ssm@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.22.0.tgz#60d360e3aa904832be69f09df19052d9e5613c90"
+  integrity sha512-F9NZHqasENpCplqvXs2q64Ribt2RDHtstBlHZiq2OzGyuXFqIwyZcpG1GgIjJUUclwNRmAAFZk4EudlKuJ6dnA==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.22.0"
+    "@aws-cdk/aws-kms" "1.22.0"
+    "@aws-cdk/core" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
+
+"@aws-cdk/cfnspec@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.22.0.tgz#3ae4c59c48441935a8c808702c204e53b4433879"
+  integrity sha512-2RYtdveWQvZkYaWB0sQjuU5pBJO8C2Hg+o1NPv7vUqSm9sPfcJOniFmx1SoRn+E6GZtriv+zXOnsfhmVQRAuGw==
   dependencies:
     md5 "^2.2.1"
 
-"@aws-cdk/cloudformation-diff@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.21.0.tgz#7e1fe6ea0a35bf17ea69abebacccd727f3e90a74"
-  integrity sha512-6MPviY4ezEfZpLE+hHuetCdCoC7t36eJwhFjl2YfVPZoi5r09+/0/31bdJHE+tNXosGco6LW+wQEbKDglU4XEA==
+"@aws-cdk/cloudformation-diff@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.22.0.tgz#883c533dbfd8b7dcfffd354c80911af84bb3e018"
+  integrity sha512-yaODrpcTONt15352AzKDQJZeyH92jps9qHAFZonpkNP/BYZkRd3mnL2/e/Xh9Mx5d7YF3X0o68LIdTx/71vOVg==
   dependencies:
-    "@aws-cdk/cfnspec" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/cfnspec" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
     colors "^1.4.0"
     diff "^4.0.2"
     fast-deep-equal "^3.1.1"
     string-width "^4.2.0"
     table "^5.4.6"
 
-"@aws-cdk/core@1.21.0", "@aws-cdk/core@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.21.0.tgz#7dc97f05268a6d376a71c68030e5b60c7ab235ef"
-  integrity sha512-LpdGWrawxYazeRKE5SpQ22Ph0oEveeUlnw4SHpDwHmp8pCrAQQ2sxJrNQjLDb5qCyLjjkacvVM30CBlLbNSyeg==
+"@aws-cdk/core@1.22.0", "@aws-cdk/core@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.22.0.tgz#45cc5e962e71c34988d243104711b5558dcb4bc1"
+  integrity sha512-SD0PIOEnZ97ghF4bIf097U9l9jPtPQ5u8Uv9Uh4VwwwIPR6H07O5Qpkoj6rUwSmXc6HUlBL9OKcVjW47kMorNQ==
   dependencies:
-    "@aws-cdk/cx-api" "1.21.0"
+    "@aws-cdk/cx-api" "1.22.0"
 
-"@aws-cdk/cx-api@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.21.0.tgz#cdc0075c6b4ef27aee21700e9be198c87b5e8b15"
-  integrity sha512-+t6r/KFO7NjTodJWbRtadvX7jMV/YOdjqB+ZL6k9M/sRU00X4dGHQWn0GatvlpJTCurQi/TTCLGd9JUDWtmOaA==
+"@aws-cdk/cx-api@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.22.0.tgz#d8da5332d65c1befb73c455b316b9e4e3ea789f1"
+  integrity sha512-Pf1s+7sjjTBZbTZIdwwB2V+HU2MteXIUETGQOr+MLLMHqXhLTIh+kTrkdiHT2A3MQ6naZf7uP+cOlLQsHe2IlQ==
   dependencies:
     semver "^7.1.1"
 
-"@aws-cdk/region-info@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.21.0.tgz#b65237ad7badec7a26a7d7464a9151e308dcfa5f"
-  integrity sha512-xOEdfOLVasN4/96k/7IX4hNW1/v7koKQuKkA5fyetPKivM6Kw0FC/KWwCi3cyvCuZoTA4hHqmSDpCP/7AGj5AA==
+"@aws-cdk/region-info@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.22.0.tgz#49d33b3fab229fa3f476f222474a5467bfd76607"
+  integrity sha512-9PTBQ8f87fCQM7v8602Ir6IZThAxPOZvkNILqsyyVVpAJeCeI4aDBC4H4hFfm02Igkx1VJUhiB+RdLMDSo0+HQ==
 
 "@babel/code-frame@7.5.5":
   version "7.5.5"
@@ -2808,16 +2815,16 @@ autoprefixer@^9.7.2:
     postcss "^7.0.26"
     postcss-value-parser "^4.0.2"
 
-aws-cdk@^1.21.0:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.21.0.tgz#f7e12e437aa90952c4c916b2e78d5d2df56bcc63"
-  integrity sha512-Abiv3WMgtAMQOT+6/BlVYaWLVAdd/MACizV9/A9U/YGO+5BaYcr1VrJMfvQQoY9wxrg6Q+Q3WPE3fdgUvPSdJQ==
+aws-cdk@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.22.0.tgz#61bb6156cd46e30339b828e604b4edf8a2d6bcf1"
+  integrity sha512-hd1BDhlR/TYRjy6mK2TSJaPHZo3wvxYXfNS/w1PxmhKyeDTEOn/8CLaWMDaTN2nzoHr6iW//3J7yRUafmrLIVw==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "1.21.0"
-    "@aws-cdk/cx-api" "1.21.0"
-    "@aws-cdk/region-info" "1.21.0"
+    "@aws-cdk/cloudformation-diff" "1.22.0"
+    "@aws-cdk/cx-api" "1.22.0"
+    "@aws-cdk/region-info" "1.22.0"
     archiver "^3.1.1"
-    aws-sdk "^2.601.0"
+    aws-sdk "^2.608.0"
     camelcase "^5.3.1"
     colors "^1.4.0"
     decamelize "^3.2.0"
@@ -2831,14 +2838,29 @@ aws-cdk@^1.21.0:
     semver "^7.1.1"
     source-map-support "^0.5.16"
     table "^5.4.6"
-    uuid "^3.3.3"
+    uuid "^3.4.0"
     yaml "^1.7.2"
     yargs "^15.0.2"
 
-aws-sdk@^2.481.0, aws-sdk@^2.601.0, aws-sdk@^2.604.0:
+aws-sdk@^2.481.0, aws-sdk@^2.604.0:
   version "2.604.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.604.0.tgz#b05a1540d6ee448f5545e4f829ad9606c480aebb"
   integrity sha512-5SmC/3YL2Zve9SFeeL/xaUbsxwW2EfwsAi/WTCAwxRUGehT7FNO8Ojiv0u02aODEBSTssugDZw21ka+dC3l/Yw==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.608.0:
+  version "2.611.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.611.0.tgz#b1da3bc62740347201b1fa53b7009b306b1627de"
+  integrity sha512-2Y0vqEUQFRJE/5Ne6IYgP2y+8XEp0jQefHxlwdqwj9n9a8OmdsmBnNaw2IVsyxySgk2ynp38+imBJaceDNKiiQ==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -11442,12 +11464,12 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^3.1.0:
+uuid@^3.1.0, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
@tjmw and I worked on this to migrate from API Gateway REST to HTTP. 

See:

https://aws.amazon.com/blogs/compute/announcing-http-apis-for-amazon-api-gateway/

for info on this. 

The TL;DR version is:

* HTTP is simpler but still suitable for proxying to a lambda (which is what we do)
* it's considerably cheaper (1/3 the cost for the request part of API Gateways costs)  

Note, HTTP Apis are in beta at the moment so the library/interface is still subject to change. But we think the risk here is worth it.