### PR TITLE
Validate /epic Request Payloads with JSON Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ $ PORT=8080 yarn dev # override the port to listen on
 $ yarn test
 $ yarn test path/to/specific/test.ts
 ```
+
+## Update JSON Schema
+
+Update JSON schema based on TypeScript definitions:
+
+$ yarn generate-schema

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -4,6 +4,7 @@ set -e
 
 cp package.json dist/
 cp yarn.lock dist/
+cp -r src/schemas dist/
 cd dist
 yarn install --production
 cd ..

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "upload-artifact": "node-riffraff-artifact",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "generate-schema": "ts-node ./src/scripts/generate-json-schema.ts"
   },
   "dependencies": {
     "@guardian/src-foundations": "^0.12.4",
@@ -28,6 +29,7 @@
     "emotion": "^10.0.27",
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
+    "jsonschema": "^1.2.5",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
@@ -72,6 +74,7 @@
     "ts-jest": "^24.3.0",
     "ts-loader": "^6.2.1",
     "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "typescript-json-schema": "^0.42.0"
   }
 }

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -1,4 +1,4 @@
-import { EpicTracking, EpicLocalisation, EpicTargeting } from './ContributionsEpic';
+import { EpicTracking, EpicLocalisation, EpicTargeting } from './ContributionsEpicTypes';
 
 const content = {
     heading: 'Since you’re here...',
@@ -38,30 +38,22 @@ const targeting: EpicTargeting = {
         {
             id: 'culture/david-schwimmer',
             type: 'Keyword',
-            title: 'David Schwimmer',
         },
         {
             id: 'tv-and-radio/friends',
             type: 'Keyword',
-            title: 'Friends',
         },
         {
             id: 'tone/interview',
             type: 'Tone',
-            title: 'Interviews',
         },
         {
             id: 'publication/theguardian',
             type: 'Publication',
-            title: 'The Guardian',
         },
         {
             id: 'profile/davidsmith',
             type: 'Contributor',
-            title: 'David Smith',
-            twitterHandle: 'smithinamerica',
-            bylineImageUrl:
-                'https://i.guim.co.uk/img/uploads/2017/10/06/David-Smith,-L.png?width=300&quality=85&auto=format&fit=max&s=9aebe85c96f6f72a6ba6239cdfaed7ec',
         },
     ],
 };

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -6,6 +6,7 @@ import { space } from '@guardian/src-foundations';
 import { PrimaryButton } from './PrimaryButton';
 import { getTrackingUrl } from '../lib/tracking';
 import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
+import { EpicLocalisation, EpicTracking } from './ContributionsEpicTypes';
 
 const replacePlaceholders = (content: string, countryCode?: string): string => {
     // Replace currency symbol placeholder with actual currency symbol
@@ -76,37 +77,6 @@ export type EpicContent = {
     paragraphs: string[];
     highlighted: string[];
     countryCode?: string;
-};
-
-export type EpicLocalisation = {
-    countryCode: string;
-};
-
-export type EpicTracking = {
-    ophanPageId: string;
-    ophanComponentId: string;
-    platformId: string;
-    campaignCode: string;
-    abTestName: string;
-    abTestVariant: string;
-    referrerUrl: string;
-};
-
-export type Tag = {
-    id: string;
-    type: string;
-    title: string;
-    twitterHandle?: string;
-    bylineImageUrl?: string;
-};
-
-export type EpicTargeting = {
-    contentType: string;
-    sectionName: string;
-    shouldHideReaderRevenue: boolean;
-    isMinuteArticle: boolean;
-    isPaidContent: boolean;
-    tags: Tag[];
 };
 
 export type Props = {

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -1,0 +1,33 @@
+export type EpicLocalisation = {
+    countryCode: string;
+};
+
+export type EpicTracking = {
+    ophanPageId: string;
+    ophanComponentId: string;
+    platformId: string;
+    campaignCode: string;
+    abTestName: string;
+    abTestVariant: string;
+    referrerUrl: string;
+};
+
+export type Tag = {
+    id: string;
+    type: string;
+};
+
+export type EpicTargeting = {
+    contentType: string;
+    sectionName: string;
+    shouldHideReaderRevenue: boolean;
+    isMinuteArticle: boolean;
+    isPaidContent: boolean;
+    tags: Tag[];
+};
+
+export type EpicPayload = {
+    tracking: EpicTracking;
+    localisation: EpicLocalisation;
+    targeting: EpicTargeting;
+};

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -1,4 +1,4 @@
-import { EpicTargeting, Tag } from '../components/ContributionsEpic';
+import { EpicTargeting, Tag } from '../components/ContributionsEpicTypes';
 
 // Content types allowed to be considered for an Epic
 const ACCEPTED_TYPES = ['Article'];

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,4 +1,4 @@
-import { EpicTracking } from '../components/ContributionsEpic';
+import { EpicTracking } from '../components/ContributionsEpicTypes';
 
 type LinkParams = {
     REFPVID: string;

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -1,0 +1,103 @@
+{
+    "type": "object",
+    "properties": {
+        "tracking": {
+            "type": "object",
+            "properties": {
+                "ophanPageId": {
+                    "type": "string"
+                },
+                "ophanComponentId": {
+                    "type": "string"
+                },
+                "platformId": {
+                    "type": "string"
+                },
+                "campaignCode": {
+                    "type": "string"
+                },
+                "abTestName": {
+                    "type": "string"
+                },
+                "abTestVariant": {
+                    "type": "string"
+                },
+                "referrerUrl": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "abTestName",
+                "abTestVariant",
+                "campaignCode",
+                "ophanComponentId",
+                "ophanPageId",
+                "platformId",
+                "referrerUrl"
+            ]
+        },
+        "localisation": {
+            "type": "object",
+            "properties": {
+                "countryCode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "countryCode"
+            ]
+        },
+        "targeting": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "sectionName": {
+                    "type": "string"
+                },
+                "shouldHideReaderRevenue": {
+                    "type": "boolean"
+                },
+                "isMinuteArticle": {
+                    "type": "boolean"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "type"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "contentType",
+                "isMinuteArticle",
+                "isPaidContent",
+                "sectionName",
+                "shouldHideReaderRevenue",
+                "tags"
+            ]
+        }
+    },
+    "required": [
+        "localisation",
+        "targeting",
+        "tracking"
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/src/scripts/generate-json-schema.ts
+++ b/src/scripts/generate-json-schema.ts
@@ -1,0 +1,29 @@
+import * as TJS from 'typescript-json-schema';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const basePath = './src';
+
+const settings = {
+    required: true,
+};
+
+const compilerOptions = {
+    strictNullChecks: true,
+};
+
+const program = TJS.getProgramFromFiles(
+    [path.resolve('./src/components/ContributionsEpicTypes.ts')],
+    compilerOptions,
+    basePath,
+);
+
+const schema = TJS.generateSchema(program, 'EpicPayload', settings);
+
+const schemaPath = path.join(__dirname, '../schemas/epicPayload.schema.json');
+
+fs.writeFile(schemaPath, JSON.stringify(schema, null, 4), 'utf8', err => {
+    if (err) {
+        console.log(err);
+    }
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -31,4 +31,12 @@ describe('POST /epic', () => {
         expect(res.body.data).toHaveProperty('html');
         expect(res.body.data).toHaveProperty('css');
     });
+
+    it('returns a 400 when an invalid payload is sent', async () => {
+        const res = await request(app)
+            .post('/epic')
+            .send({});
+
+        expect(res.status).toEqual(400);
+    });
 });

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -6,18 +6,20 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
 import { fetchDefaultEpicContent } from './api/contributionsApi';
-import {
-    ContributionsEpic,
-    EpicTracking,
-    EpicLocalisation,
-    EpicTargeting,
-} from './components/ContributionsEpic';
+import { ContributionsEpic } from './components/ContributionsEpic';
+import { EpicTracking, EpicLocalisation, EpicTargeting } from './components/ContributionsEpicTypes';
 import { shouldRenderEpic } from './lib/targeting';
 import testData from './components/ContributionsEpic.testData';
 import cors from 'cors';
+import { Validator } from 'jsonschema';
+import * as fs from 'fs';
+import * as path from 'path';
 
 // Pre-cache API response
 fetchDefaultEpicContent();
+
+const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
+const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
 
 // Use middleware
 const app = express();
@@ -35,10 +37,6 @@ app.get('/healthcheck', (req: express.Request, res: express.Response) => {
 interface Epic {
     html: string;
     css: string;
-}
-
-interface ResponseType {
-    data: Epic | null;
 }
 
 // Return a metadata object safe to be consumed by the Epic component
@@ -134,13 +132,23 @@ app.get(
     },
 );
 
+class ValidationError extends Error {}
+
 app.post(
     '/epic',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
+            const validator = new Validator();
+            const validation = validator.validate(req.body, epicPayloadSchema);
+
+            if (!validation.valid) {
+                throw new ValidationError(validation.toString());
+            }
+
             const tracking = buildTracking(req);
             const localisation = buildLocalisation(req);
             const targeting = buildTargeting(req);
+
             const epic = await buildEpic(tracking, localisation, targeting);
             res.send({ data: epic });
         } catch (error) {
@@ -153,8 +161,17 @@ app.post(
 // for it to run when `next()` function is called in the route handler
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((error: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
-    console.log('Something went wrong: ', error.message);
-    res.status(500).send({ error: error.message });
+    const { message } = error;
+
+    switch (error.constructor) {
+        case ValidationError:
+            res.status(400).send({ error: message });
+            break;
+        default:
+            res.status(500).send({ error: message });
+    }
+
+    console.log('Something went wrong: ', message);
 });
 
 // If local then don't wrap in serverless

--- a/yarn.lock
+++ b/yarn.lock
@@ -5947,7 +5947,7 @@ glob-to-regexp@^0.4.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -7402,6 +7402,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -7439,6 +7446,16 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonschema@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.5.tgz#bab69d97fa28946aec0a56a9cc266d23fe80ae61"
+  integrity sha512-kVTF+08x25PQ0CjuVc0gRM9EUPb0Fe9Ln/utFOgcdxEIOHuU7ooBk/UPTd7t1M91pP35m0MU1T8M5P7vP1bRRw==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -11312,6 +11329,22 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript-json-schema@^0.42.0:
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.42.0.tgz#695f212a72d91d47c0605371dc697597b7817c1b"
+  integrity sha512-9WO+lVmlph7Ecb7lPd9tU84XFUQh44kpAf3cWe/Ym4G5EKw/SS6XGpi1DZDthvxqkIdNSDlWi7FhKfxuIV/3yw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    glob "~7.1.4"
+    json-stable-stringify "^1.0.1"
+    typescript "^3.5.3"
+    yargs "^14.0.0"
+
+typescript@^3.5.3:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
 typescript@^3.7.4:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
@@ -11936,6 +11969,14 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
+  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^16.1.0:
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
@@ -11985,6 +12026,23 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^14.0.0:
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.2.tgz#2769564379009ff8597cdd38fba09da9b493c4b5"
+  integrity sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.0"
 
 yargs@^15.0.2:
   version "15.1.0"


### PR DESCRIPTION
This PR introduces a JSON schema document to illustrate the format that the `POST /epic` endpoint expects of the request body.

We also now use the schema to validate the incoming payload. If the request payload isn't the correct format then we'll return `400 Bad Request`.

Anecdotally the validation seems to increase response times by a few milliseconds, but this doesn't seem problematic.

Since this adds even more logic to `src/server.tsx` We have a refactoring to split that file up into separate concerns on another branch (but didn't want to include on this PR because it would have obscured the json schema changes).