### PR TITLE
Log when we fetch default content

### DIFF
--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -12,6 +12,8 @@ export type DefaultEpicContent = {
 let epicContent: Promise<DefaultEpicContent> | undefined;
 
 const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicContent> => {
+    const startTime = new Date().getTime();
+
     const response = await fetch(defaultEpicUrl);
     if (!response.ok) {
         throw new Error(
@@ -21,7 +23,7 @@ const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicConte
     const data = await response.json();
     const control = data?.sheets?.control;
 
-    return control.reduce(
+    const transformedData = control.reduce(
         (
             acc: DefaultEpicContent,
             item: { heading: string; paragraphs: string; highlightedText: string },
@@ -39,6 +41,11 @@ const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicConte
         },
         { paragraphs: [], highlighted: [] },
     );
+
+    const endTime = new Date().getTime();
+    console.log(`Fetched default epic content. Time elapsed: ${endTime - startTime}ms`);
+
+    return transformedData;
 };
 
 export const fetchDefaultEpicContent = (): Promise<DefaultEpicContent> => {


### PR DESCRIPTION
This will help inform our caching strategy for the content.

One thing to note: currently the console log output is visible when running jest tests, which I find really annoying and distracting! I'm going to try out some options and follow up in a separate PR to fix this, but don't want to block this change going out.

![Screenshot 2020-02-11 at 10 10 24](https://user-images.githubusercontent.com/379839/74227668-e05a6200-4cb6-11ea-88cb-16986c38974a.png)
