### PR TITLE
Log when we load the JSON schema

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -20,6 +20,7 @@ fetchDefaultEpicContent();
 
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+console.log('Loaded epic payload JSON schema');
 
 // Use middleware
 const app = express();


### PR DESCRIPTION
In the same way it's useful to keep an eye on when we fetch the default epic content, I think it'll be useful to know how often we're reading/loading this.