### PR TITLE
Make countryCode optional

### DIFF
--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -31,7 +31,7 @@ export const defaultStory = (): ReactElement => {
 
     // Epic localisation props
     const epicLocalisation = {
-        countryCode: text('countryCode', testData.localisation.countryCode),
+        countryCode: text('countryCode', testData.localisation.countryCode || ''),
     };
 
     return (

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -8,7 +8,7 @@ import { getTrackingUrl } from '../lib/tracking';
 import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicLocalisation, EpicTracking } from './ContributionsEpicTypes';
 
-const replacePlaceholders = (content: string, countryCode?: string): string => {
+const replacePlaceholders = (content: string, countryCode: string | null): string => {
     // Replace currency symbol placeholder with actual currency symbol
     // Function uses default currency symbol so countryCode is not strictly required here
     content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
@@ -76,7 +76,6 @@ export type EpicContent = {
     heading?: string;
     paragraphs: string[];
     highlighted: string[];
-    countryCode?: string;
 };
 
 export type Props = {
@@ -87,13 +86,13 @@ export type Props = {
 
 type HighlightedProps = {
     highlighted: string[];
-    countryCode?: string;
+    countryCode: string | null;
 };
 
 type BodyProps = {
     paragraphs: string[];
     highlighted: string[];
-    countryCode?: string;
+    countryCode: string | null;
 };
 
 const Highlighted: React.FC<HighlightedProps> = ({

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -1,5 +1,5 @@
 export type EpicLocalisation = {
-    countryCode: string;
+    countryCode: string | null;
 };
 
 export type EpicTracking = {

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -378,7 +378,7 @@ const defaultCurrencySymbol = '£';
 // returned if we don't have a geolocation. But if we do have a geolocation, but
 // fail to map back to a country group then we'll fall back to 'USD'.
 // We're not sure whether this is intentional or not yet but porting as is for now
-export const getLocalCurrencySymbol = (geolocation?: string): string => {
+export const getLocalCurrencySymbol = (geolocation: string | null): string => {
     if (geolocation) {
         const countryGroupId = countryCodeToCountryGroupId(geolocation) as CountryGroupId;
         return extendedCurrencySymbol[countryGroupId];
@@ -387,7 +387,7 @@ export const getLocalCurrencySymbol = (geolocation?: string): string => {
     return defaultCurrencySymbol;
 };
 
-export const getCountryName = (geolocation?: string): string | undefined => {
+export const getCountryName = (geolocation: string | null): string | undefined => {
     if (geolocation) {
         return countryNames[geolocation];
     }

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -40,7 +40,10 @@
             "type": "object",
             "properties": {
                 "countryCode": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             },
             "required": [

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -32,11 +32,31 @@ describe('POST /epic', () => {
         expect(res.body.data).toHaveProperty('css');
     });
 
+    it('should return an epic when targeting is positive and country code is null', async () => {
+        const { tracking, targeting } = testData;
+
+        const res = await request(app)
+            .post('/epic')
+            .send({
+                tracking,
+                localisation: {
+                    countryCode: null,
+                },
+                targeting,
+            });
+
+        expect(res.status).toEqual(200);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data).toHaveProperty('html');
+        expect(res.body.data).toHaveProperty('css');
+    });
+
     it('returns a 400 when an invalid payload is sent', async () => {
         const res = await request(app)
             .post('/epic')
             .send({});
 
         expect(res.status).toEqual(400);
+        expect(res.body).toHaveProperty('error');
     });
 });

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -65,7 +65,7 @@ const buildTracking = (req: express.Request): EpicTracking => {
 
 const buildLocalisation = (req: express.Request): EpicLocalisation => {
     const { countryCode } = req.body.localisation;
-    return { countryCode };
+    return { countryCode: countryCode || null };
 };
 
 const buildTargeting = (req: express.Request): EpicTargeting => {


### PR DESCRIPTION
After deploying the JSON schema change we noticed that we were seeing lots of 400 responses because countryCode was missing. At the moment we can render the epic without a country code (we only use it for the currency, and we fallback on £).