### PR TITLE
Catch and log a failed epic pre-fetch

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -16,7 +16,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 // Pre-cache API response
-fetchDefaultEpicContent();
+fetchDefaultEpicContent().catch(error =>
+    console.log('Failed to pre-fetch default epic content:', error),
+);
 
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));


### PR DESCRIPTION
Log if this happens. The outcome will just be that the next time a request arrives we’ll attempt to fetch the content then. The function `fetchDefaultEpicContent` is lazy and caches the first successful result.