### PR TITLE
Add HTTP Response Logging

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -33,7 +33,7 @@ app.options('*', cors());
 // Logging
 app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
     next();
-    console.log({ status: res.statusCode, method: req.method, path: req.path });
+    console.log(JSON.stringify({ status: res.statusCode, method: req.method, path: req.path }));
 });
 
 app.get('/healthcheck', (req: express.Request, res: express.Response) => {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -30,6 +30,12 @@ app.use(express.json({ limit: '50mb' }));
 app.use(cors());
 app.options('*', cors());
 
+// Logging
+app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+    next();
+    console.log({ status: res.statusCode, method: req.method, path: req.path });
+});
+
 app.get('/healthcheck', (req: express.Request, res: express.Response) => {
     res.header('Content-Type', 'text/plain');
     res.send('OK');


### PR DESCRIPTION
I think it would be useful to see at a glance (perhaps on a dashboard or something in Kibana) the breakdown of response codes we're serving. This would allow us to spot issues faster.  This adds some logging on every request of the response code, HTTP method and path. Logging a JSON string sends the data to ELK in a structured way and allows us to query it easily.

A few requests logged on CODE:

![Screenshot 2020-02-14 at 16 45 06](https://user-images.githubusercontent.com/379839/74550677-ac4a9f80-4f49-11ea-9e92-dbc7808b3eb4.png)

This was all a bit more manual than I expected, so any alternative approaches/suggestions appreciated!