### PR TITLE
Disable JSON schema validation

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -33,7 +33,7 @@ describe('POST /epic', () => {
     });
 
     // Skip this test until JSON schema validation is configurable
-    test.skip('returns a 400 when an invalid payload is sent', async () => {
+    it('returns a 400 when an invalid payload is sent', async () => {
         const res = await request(app)
             .post('/epic')
             .send({});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -32,7 +32,8 @@ describe('POST /epic', () => {
         expect(res.body.data).toHaveProperty('css');
     });
 
-    it('returns a 400 when an invalid payload is sent', async () => {
+    // Skip this test until JSON schema validation is configurable
+    xit('returns a 400 when an invalid payload is sent', async () => {
         const res = await request(app)
             .post('/epic')
             .send({});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -33,7 +33,7 @@ describe('POST /epic', () => {
     });
 
     // Skip this test until JSON schema validation is configurable
-    xit('returns a 400 when an invalid payload is sent', async () => {
+    test.skip('returns a 400 when an invalid payload is sent', async () => {
         const res = await request(app)
             .post('/epic')
             .send({});

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -7,15 +7,18 @@ import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
 import { fetchDefaultEpicContent } from './api/contributionsApi';
 import { ContributionsEpic } from './components/ContributionsEpic';
-import { EpicTracking, EpicLocalisation, EpicTargeting } from './components/ContributionsEpicTypes';
+import {
+    EpicTracking,
+    EpicLocalisation,
+    EpicTargeting,
+    EpicPayload,
+} from './components/ContributionsEpicTypes';
 import { shouldRenderEpic } from './lib/targeting';
 import testData from './components/ContributionsEpic.testData';
 import cors from 'cors';
 import { Validator } from 'jsonschema';
 import * as fs from 'fs';
 import * as path from 'path';
-
-const PERFORM_JSON_SCHEMA_VALIDATION = false;
 
 // Pre-cache API response
 fetchDefaultEpicContent();
@@ -41,54 +44,6 @@ interface Epic {
     html: string;
     css: string;
 }
-
-// Return a metadata object safe to be consumed by the Epic component
-const buildTracking = (req: express.Request): EpicTracking => {
-    const {
-        ophanPageId,
-        ophanComponentId,
-        platformId,
-        campaignCode,
-        abTestName,
-        abTestVariant,
-        referrerUrl,
-    } = req.body.tracking;
-
-    return {
-        ophanPageId,
-        ophanComponentId,
-        platformId,
-        campaignCode,
-        abTestName,
-        abTestVariant,
-        referrerUrl,
-    };
-};
-
-const buildLocalisation = (req: express.Request): EpicLocalisation => {
-    const { countryCode } = req.body.localisation;
-    return { countryCode };
-};
-
-const buildTargeting = (req: express.Request): EpicTargeting => {
-    const {
-        contentType,
-        sectionName,
-        shouldHideReaderRevenue,
-        isMinuteArticle,
-        isPaidContent,
-        tags,
-    } = req.body.targeting;
-
-    return {
-        contentType,
-        sectionName,
-        shouldHideReaderRevenue,
-        isMinuteArticle,
-        isPaidContent,
-        tags,
-    };
-};
 
 // Return the HTML and CSS from rendering the Epic to static markup
 const buildEpic = async (
@@ -125,6 +80,11 @@ app.get(
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const { tracking, localisation, targeting } = testData;
+
+            if (process.env.NODE_ENV !== 'production') {
+                validatePayload(testData);
+            }
+
             const epic = await buildEpic(tracking, localisation, targeting);
             const { html, css } = epic ?? { html: '', css: '' };
             const htmlContent = renderHtmlDocument({ html, css });
@@ -136,31 +96,28 @@ app.get(
 );
 
 class ValidationError extends Error {}
+const validator = new Validator(); // reuse as expensive to initialise
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const validatePayload = (body: any): void => {
-    if (!PERFORM_JSON_SCHEMA_VALIDATION) {
-        return;
-    }
-
-    const validator = new Validator();
+const validatePayload = (body: any): EpicPayload => {
     const validation = validator.validate(body, epicPayloadSchema);
 
     if (!validation.valid) {
         throw new ValidationError(validation.toString());
     }
+
+    return body as EpicPayload;
 };
 
 app.post(
     '/epic',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
-            validatePayload(req.body);
+            if (process.env.NODE_ENV !== 'production') {
+                validatePayload(req.body);
+            }
 
-            const tracking = buildTracking(req);
-            const localisation = buildLocalisation(req);
-            const targeting = buildTargeting(req);
-
+            const { tracking, localisation, targeting } = req.body;
             const epic = await buildEpic(tracking, localisation, targeting);
             res.send({ data: epic });
         } catch (error) {


### PR DESCRIPTION
At the moment this is configured via a const which is hardcoded to false. I think going forward we could pull this value from configuration in parameter store (or similar) so we can toggle it per environment, but I didn't get to this today.

We discussed not enabling in prod (it does after all have a small performance penalty) but I can see it continuing to be useful in CODE and DEV, especially when integrating with the service.

Another option in the short term might be to do the validation in PROD but simply log the output (and don’t return a 400). This would allow us to gather data on whether our understanding of the input params is correct.