### PR TITLE
Make countryCode type optional

### DIFF
--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -31,7 +31,7 @@ export const defaultStory = (): ReactElement => {
 
     // Epic localisation props
     const epicLocalisation = {
-        countryCode: text('countryCode', testData.localisation.countryCode),
+        countryCode: text('countryCode', testData.localisation.countryCode || 'GB'),
     };
 
     return (

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -1,5 +1,5 @@
 export type EpicLocalisation = {
-    countryCode: string;
+    countryCode?: string;
 };
 
 export type EpicTracking = {

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -42,10 +42,7 @@
                 "countryCode": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "countryCode"
-            ]
+            }
         },
         "targeting": {
             "type": "object",


### PR DESCRIPTION
This makes the `countryCode` property optional so the JSON schema doesn't fail when the value coming from the platform is `undefined`.

It will still fail if the value is `null` but I don't think we have a use case for that. In frontend, when the country cannot be fetched from localStorage, it will be inferred from the Edition, through a function that will either return a string (edition code) or `undefined`.