### PR TITLE
Exclude CDK metadata from synth output

### DIFF
--- a/bin/package.sh
+++ b/bin/package.sh
@@ -8,4 +8,4 @@ cp -r src/schemas dist/
 cd dist
 yarn install --production
 cd ..
-cdk --profile frontend synth > cloudformation.yaml
+cdk --profile frontend synth --version-reporting false > cloudformation.yaml


### PR DESCRIPTION
Motivation is that this seems to update frequently, slowing deploys unnecessarily.

E.g. from recent deploy, only things that changed:

![Screenshot 2020-02-26 at 12 39 55](https://user-images.githubusercontent.com/858402/75345700-2279cb00-5895-11ea-9424-fe69f0d741df.png)

Because our cdk code is version controlled and our dependencies pinned, we don't really need to store this metadata in the cloudformation as well.