### PR TITLE
Don’t cache a failed epic content fetch

### DIFF
--- a/src/api/contributionsApi.test.ts
+++ b/src/api/contributionsApi.test.ts
@@ -1,32 +1,38 @@
-import { fetchDefaultEpicContent } from './contributionsApi';
+import { fetchDefaultEpicContent, clearCachedEpic } from './contributionsApi';
 
 jest.mock('node-fetch', () => require('fetch-mock').sandbox());
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetchMock = require('node-fetch');
+fetchMock.config.overwriteRoutes = true;
+
+const epicUrl =
+    'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
+
+const epicResponse = {
+    sheets: {
+        control: [
+            {
+                heading: 'Since you’re here...',
+                paragraphs: 'First paragraph',
+                highlightedText: 'Highlighted Text',
+            },
+            {
+                heading: '',
+                paragraphs: 'Second paragraph',
+                highlightedText: '',
+            },
+        ],
+    },
+};
+
+beforeEach(() => {
+    clearCachedEpic();
+    fetchMock.resetHistory();
+});
 
 describe('fetchDefaultEpic', () => {
     it('fetches and returns the data in the expected format', async () => {
-        const url =
-            'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
-
-        const response = {
-            sheets: {
-                control: [
-                    {
-                        heading: 'Since you’re here...',
-                        paragraphs: 'First paragraph',
-                        highlightedText: 'Highlighted Text',
-                    },
-                    {
-                        heading: '',
-                        paragraphs: 'Second paragraph',
-                        highlightedText: '',
-                    },
-                ],
-            },
-        };
-
-        fetchMock.get(url, response);
+        fetchMock.get(epicUrl, epicResponse);
 
         const epicData = await fetchDefaultEpicContent();
 
@@ -35,5 +41,27 @@ describe('fetchDefaultEpic', () => {
             paragraphs: ['First paragraph', 'Second paragraph'],
             highlighted: ['Highlighted Text'],
         });
+    });
+
+    it('caches successful epic fetches', async () => {
+        fetchMock.get(epicUrl, epicResponse);
+
+        await fetchDefaultEpicContent();
+        await fetchDefaultEpicContent();
+
+        expect(fetchMock.calls().length).toEqual(1);
+    });
+
+    it('does not cache unsuccessful epic fetches', async () => {
+        fetchMock.get(epicUrl, { status: 500 });
+
+        try {
+            await fetchDefaultEpicContent();
+        } catch {}
+        try {
+            await fetchDefaultEpicContent();
+        } catch {}
+
+        expect(fetchMock.calls().length).toEqual(2);
     });
 });

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -9,7 +9,7 @@ export type DefaultEpicContent = {
     highlighted: string[];
 };
 
-let epicContent: Promise<DefaultEpicContent> | undefined;
+let cachedEpic: DefaultEpicContent | undefined;
 
 const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicContent> => {
     const startTime = new Date().getTime();
@@ -48,12 +48,16 @@ const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicConte
     return transformedData;
 };
 
-export const fetchDefaultEpicContent = (): Promise<DefaultEpicContent> => {
-    if (epicContent) {
-        return epicContent;
+export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => {
+    if (cachedEpic) {
+        return cachedEpic;
     }
 
-    epicContent = fetchDefaultEpicContentWithoutCaching();
+    cachedEpic = await fetchDefaultEpicContentWithoutCaching();
 
-    return epicContent;
+    return cachedEpic;
+};
+
+export const clearCachedEpic = (): void => {
+    cachedEpic = undefined;
 };

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -20,11 +20,6 @@ import { Validator } from 'jsonschema';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// Pre-cache API response
-fetchDefaultEpicContent().catch(error =>
-    console.log('Failed to pre-fetch default epic content:', error),
-);
-
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
 console.log('Loaded epic payload JSON schema');


### PR DESCRIPTION
Previously if the default epic content fetch failed we were caching that result, which we don't want to be doing. Only cache if we were successful. I also beefed up the tests a little to cover these scenarios.