### PR TITLE
Fix HTTP response code logging

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -34,8 +34,10 @@ app.options('*', cors());
 
 // Logging
 app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+    res.on('finish', () =>
+        console.log(JSON.stringify({ status: res.statusCode, method: req.method, path: req.path })),
+    );
     next();
-    console.log(JSON.stringify({ status: res.statusCode, method: req.method, path: req.path }));
 });
 
 app.get('/healthcheck', (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
We were noticing that 400/500 responses didn’t seem to be getting logged correctly. Having tested locally this improves things. So the middleware runs before the main handler, but attaches a listener to log when the request completes. This seems to do the right thing and I now see 200,
400 and 500 responses logged correctly locally.