### PR TITLE
Comparison endpoint to help us evaluate our variant logic

### DIFF
--- a/src/api/contributionsApi.test.ts
+++ b/src/api/contributionsApi.test.ts
@@ -1,5 +1,5 @@
 import { fetchDefaultEpicContent } from './contributionsApi';
-import { memoise } from '../lib/memoise';
+import { memoiseAsync } from '../lib/memoise';
 
 jest.mock('node-fetch', () => require('fetch-mock').sandbox());
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -26,15 +26,13 @@ const epicResponse = {
     },
 };
 
-beforeEach(() => {
-    fetchMock.resetHistory();
-});
+beforeEach(fetchMock.resetHistory);
 
 describe('fetchDefaultEpic', () => {
     it('fetches and returns the data in the expected format', async () => {
         fetchMock.get(epicUrl, epicResponse);
 
-        const [reset, fetchData] = memoise(fetchDefaultEpicContent);
+        const [reset, fetchData] = memoiseAsync(fetchDefaultEpicContent);
         reset();
 
         const epicData = await fetchData();
@@ -49,7 +47,7 @@ describe('fetchDefaultEpic', () => {
     it('caches successful epic fetches', async () => {
         fetchMock.get(epicUrl, epicResponse);
 
-        const [reset, fetchData] = memoise(fetchDefaultEpicContent);
+        const [reset, fetchData] = memoiseAsync(fetchDefaultEpicContent);
         reset();
 
         await fetchData();
@@ -61,7 +59,7 @@ describe('fetchDefaultEpic', () => {
     it('does not cache unsuccessful epic fetches', async () => {
         fetchMock.get(epicUrl, { status: 500 });
 
-        const [reset, fetchData] = memoise(fetchDefaultEpicContent);
+        const [reset, fetchData] = memoiseAsync(fetchDefaultEpicContent);
         reset();
 
         try {

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import { EpicTests } from '../lib/variants';
 
 const defaultEpicUrl =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
@@ -60,4 +61,8 @@ export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => 
 
 export const clearCachedEpic = (): void => {
     cachedEpic = undefined;
+};
+
+export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
+    return {} as EpicTests; // TODO fix and memoise
 };

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -10,9 +10,7 @@ export type DefaultEpicContent = {
     highlighted: string[];
 };
 
-let cachedEpic: DefaultEpicContent | undefined;
-
-const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicContent> => {
+export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => {
     const startTime = new Date().getTime();
 
     const response = await fetch(defaultEpicUrl);
@@ -49,20 +47,6 @@ const fetchDefaultEpicContentWithoutCaching = async (): Promise<DefaultEpicConte
     return transformedData;
 };
 
-export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => {
-    if (cachedEpic) {
-        return cachedEpic;
-    }
-
-    cachedEpic = await fetchDefaultEpicContentWithoutCaching();
-
-    return cachedEpic;
-};
-
-export const clearCachedEpic = (): void => {
-    cachedEpic = undefined;
-};
-
 export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
-    return {} as EpicTests; // TODO fix and memoise
+    return {} as EpicTests;
 };

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -59,6 +59,7 @@ const targeting: EpicTargeting = {
     showSupportMessaging: true,
     isRecurringContributor: false,
     lastOneOffContributionDate: 1548979200000, // 2019-02-01
+    mvtId: 2,
 };
 
 const testData = { content, tracking, localisation, targeting };

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -30,6 +30,7 @@ export type EpicTargeting = {
     isMinuteArticle: boolean;
     isPaidContent: boolean;
     tags: Tag[];
+    mvtId: number;
     epicViewLog?: ViewLog;
     countryCode?: string;
 

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -30,7 +30,7 @@ export type EpicTargeting = {
     isMinuteArticle: boolean;
     isPaidContent: boolean;
     tags: Tag[];
-    mvtId: number;
+    mvtId?: number;
     epicViewLog?: ViewLog;
     countryCode?: string;
 

--- a/src/lib/memoise.ts
+++ b/src/lib/memoise.ts
@@ -1,16 +1,16 @@
-export const memoise = <T>(fn: () => Promise<T>): [() => void, () => Promise<T>] => {
-    let resp: T | undefined;
+export const memoiseAsync = <T>(fn: () => Promise<T>): [() => void, () => Promise<T>] => {
+    let res: T | undefined;
 
     const retFn = async () => {
-        if (resp) {
-            return resp;
+        if (res !== undefined) {
+            return res;
         }
 
-        resp = await fn();
-        return resp;
+        res = await fn();
+        return res;
     };
 
-    const resetFn = () => (resp = undefined);
+    const resetFn = () => (res = undefined);
 
     return [resetFn, retFn];
 };

--- a/src/lib/memoise.ts
+++ b/src/lib/memoise.ts
@@ -1,0 +1,16 @@
+export const memoise = <T>(fn: () => Promise<T>): [() => void, () => Promise<T>] => {
+    let resp: T | undefined;
+
+    const retFn = async () => {
+        if (resp) {
+            return resp;
+        }
+
+        resp = await fn();
+        return resp;
+    };
+
+    const resetFn = () => (resp = undefined);
+
+    return [resetFn, retFn];
+};

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -67,24 +67,23 @@ const targetingDefault: EpicTargeting = {
     showSupportMessaging: true,
     isRecurringContributor: false,
     lastOneOffContributionDate: undefined,
+    mvtId: 2,
 };
 
 describe('find variant', () => {
     it('should find the correct variant for test and targeting data', () => {
-        const mvtId = 2; // MVT IDs are 0..10^6
         const tests = { tests: [testDefault] };
         const targeting = targetingDefault;
-        const got = findVariant(tests, targeting, mvtId);
+        const got = findVariant(tests, targeting);
 
         expect(got?.name).toBe('control-example-1');
     });
 
     it('should return undefined when no matching test variant', () => {
-        const mvtId = 2; // MVT IDs are 0..10^6
         const test = { ...testDefault, excludedSections: ['news'] };
         const tests = { tests: [test] };
         const targeting = { ...targetingDefault, sectionName: 'news' };
-        const got = findVariant(tests, targeting, mvtId);
+        const got = findVariant(tests, targeting);
 
         expect(got?.name).toBe(undefined);
     });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -140,7 +140,7 @@ export const findVariant = (data: EpicTests, targeting: EpicTargeting): Variant 
     const filters: Filter[] = [
         hasSection,
         hasTags,
-        userInTest(targeting.mvtId),
+        userInTest(targeting.mvtId || 1),
         excludeSection,
         excludeTags,
         hasCountryCode,
@@ -158,5 +158,5 @@ export const findVariant = (data: EpicTests, targeting: EpicTargeting): Variant 
         }),
     );
 
-    return test ? selectVariant(test, targeting.mvtId) : undefined;
+    return test ? selectVariant(test, targeting.mvtId || 1) : undefined;
 };

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -131,11 +131,7 @@ export const hasCountryCode: Filter = {
     test: (test, targeting) => (test.hasCountryName ? !!targeting.countryCode : true),
 };
 
-export const findVariant = (
-    data: EpicTests,
-    targeting: EpicTargeting,
-    mvtId: number,
-): Variant | undefined => {
+export const findVariant = (data: EpicTests, targeting: EpicTargeting): Variant | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
 
@@ -144,7 +140,7 @@ export const findVariant = (
     const filters: Filter[] = [
         hasSection,
         hasTags,
-        userInTest(mvtId),
+        userInTest(targeting.mvtId),
         excludeSection,
         excludeTags,
         hasCountryCode,
@@ -162,5 +158,5 @@ export const findVariant = (
         }),
     );
 
-    return test ? selectVariant(test, mvtId) : undefined;
+    return test ? selectVariant(test, targeting.mvtId) : undefined;
 };

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -107,7 +107,6 @@
                 "isMinuteArticle",
                 "isPaidContent",
                 "isRecurringContributor",
-                "mvtId",
                 "sectionName",
                 "shouldHideReaderRevenue",
                 "showSupportMessaging",

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -80,6 +80,9 @@
                         ]
                     }
                 },
+                "mvtId": {
+                    "type": "number"
+                },
                 "epicViewLog": {
                     "type": "array",
                     "items": {
@@ -104,6 +107,7 @@
                 "isMinuteArticle",
                 "isPaidContent",
                 "isRecurringContributor",
+                "mvtId",
                 "sectionName",
                 "shouldHideReaderRevenue",
                 "showSupportMessaging",

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -6,7 +6,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
 import { fetchDefaultEpicContent, fetchConfiguredEpicTests } from './api/contributionsApi';
-import { memoise } from './lib/memoise';
+import { memoiseAsync } from './lib/memoise';
 import { ContributionsEpic } from './components/ContributionsEpic';
 import {
     EpicTracking,
@@ -59,7 +59,7 @@ interface Epic {
     css: string;
 }
 
-const [, fetchDefaultEpicContentCached] = memoise(fetchDefaultEpicContent);
+const [, fetchDefaultEpicContentCached] = memoiseAsync(fetchDefaultEpicContent);
 
 // Return the HTML and CSS from rendering the Epic to static markup
 const buildEpic = async (
@@ -139,7 +139,7 @@ app.post(
     },
 );
 
-const [, fetchConfiguredEpicTestsCached] = memoise(fetchConfiguredEpicTests);
+const [, fetchConfiguredEpicTestsCached] = memoiseAsync(fetchConfiguredEpicTests);
 
 app.post(
     '/epic/compare-variant-decision',


### PR DESCRIPTION
**DO NOT MERGE as adds additional targeting data requirements requiring a client-lib change first.**

The aim is that platforms (initially Frontend) can send their variant (contributions) decision to us and we can log any differences. This should help us validate that our variant logic is working correctly.

I've also generalised the memoisation logic so keen on thoughts on that too!