### PR TITLE
Upgrade foundations and update colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate-schemas": "./src/scripts/validate-schema-updates.sh"
   },
   "dependencies": {
-    "@guardian/src-foundations": "^0.12.4",
+    "@guardian/src-foundations": "^0.14.1",
     "@storybook/addon-knobs": "^5.3.8",
     "@storybook/preset-typescript": "^1.2.0",
     "aws-serverless-express": "^3.3.6",

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -25,15 +25,15 @@ const replacePlaceholders = (content: string, countryCode?: string): string => {
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
 const wrapperStyles = css`
     padding: ${space[1]}px ${space[1]}px ${space[3]}px;
-    border-top: 1px solid ${palette.brandYellow.main};
+    border-top: 1px solid ${palette.brandAlt[400]};
     background-color: ${palette.neutral[97]};
 
     * {
         ::selection {
-            background: ${palette.brandYellow.main};
+            background: ${palette.brandAlt[400]};
         }
         ::-moz-selection {
-            background: ${palette.brandYellow.main};
+            background: ${palette.brandAlt[400]};
         }
     }
 `;
@@ -55,7 +55,7 @@ const highlightWrapperStyles = css`
 
 const highlightStyles = css`
     padding: 2px;
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
 `;
 
 const buttonWrapperStyles = css`

--- a/src/components/PrimaryButton.tsx
+++ b/src/components/PrimaryButton.tsx
@@ -7,7 +7,7 @@ import { space } from '@guardian/src-foundations';
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
 const linkStyles = css`
-    background: ${palette.brandYellow.main};
+    background: ${palette.brandAlt[400]};
     border-radius: 21px;
     box-sizing: border-box;
     color: ${palette.neutral[7]} !important;
@@ -20,7 +20,7 @@ const linkStyles = css`
     transition: background-color 0.3s ease-in-out;
 
     :hover {
-        background: ${palette.brandYellow.dark};
+        background: ${palette.brandAlt[200]};
         text-decoration: none;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,10 +1201,10 @@
     aws-sdk "^2.481.0"
     yaml "^1.7.2"
 
-"@guardian/src-foundations@^0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.12.4.tgz#a4c6ec8dbf86279702d78e048e2bd4eea1624c7d"
-  integrity sha512-6V/3TWL4wMxfzUHOj5MJQMQA7oRBxWlRav5m9dYGw13JAg59DFOpcfM8LWWFwWWlJ8e2nbnDHS9/sOPzGrJduw==
+"@guardian/src-foundations@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.14.1.tgz#33cf2e95eedf184fdfc40cc75c1dbca4d6d46fdf"
+  integrity sha512-FiH2nsPvHS6wG7b0AePXTGbDCIV+q0aRHZKhsH2X2WeS9K3fZqEF9y+8lTv22nW3r3sv6nSyh4tT7y5+XPC9pA==
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
# Why are you doing this?

As part of the introduction of dark mode, the value of `brandYellow.dark` has to change from `#F3C100` to `#FFD900`. The value `#F3C100` is now considered "extra dark" 🌚  and has been moved further down the numeric brightness scale as a result.

We're treating this as a breaking change, and so we're going through codebases making the change for you 💁  The breaking change will go live in v0.15.0.

Note that we've made a couple of additional changes, to steer you away from some legacy naming conventions.

# What does this change?

- Upgrade `src-foundations` to 0.14.1
- Migrate the `brandYellow` colour category to the new name, `brandAlt`
- Use the numeric colour names associated with the brightness scale instead of deprecated semantic names

