### PR TITLE
Fetch variant config and misc fixes

### DIFF
--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -4,6 +4,8 @@ import { EpicTests } from '../lib/variants';
 const defaultEpicUrl =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 
+const configuredTestsUrl = 'https://support.theguardian.com/epic-tests.json';
+
 export type DefaultEpicContent = {
     heading?: string;
     paragraphs: string[];
@@ -48,5 +50,12 @@ export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => 
 };
 
 export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
-    return {} as EpicTests;
+    const response = await fetch(configuredTestsUrl);
+    if (!response.ok) {
+        throw new Error(
+            `Encountered a non-ok response when fetching configured epic tests: ${response.status}`,
+        );
+    }
+
+    return response.json();
 };

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -27,8 +27,11 @@ export type EpicTargeting = {
     contentType: string;
     sectionName: string;
     shouldHideReaderRevenue: boolean;
+
+    // TODO let's replace these with Design Type/a single property after migration
     isMinuteArticle: boolean;
     isPaidContent: boolean;
+
     tags: Tag[];
     mvtId?: number;
     epicViewLog?: ViewLog;

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -72,7 +72,7 @@ describe('shouldNotRenderEpic', () => {
 
 describe('shouldThrottle', () => {
     it('returns true if epic was viewed too recently', () => {
-        const config = { days: 90, count: 4, minDaysBetweenViews: 5 };
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const viewLog = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
 
         const now = new Date('2019-06-12T10:24:00');
@@ -81,7 +81,7 @@ describe('shouldThrottle', () => {
     });
 
     it('returns false if epic was not viewed too recently', () => {
-        const config = { days: 90, count: 4, minDaysBetweenViews: 5 };
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const viewLog = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
 
         const now = new Date('2019-06-17T10:24:00');
@@ -90,7 +90,7 @@ describe('shouldThrottle', () => {
     });
 
     it('returns true if epic was viewed too many times', () => {
-        const config = { days: 90, count: 4, minDaysBetweenViews: 5 };
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-07-11T10:24:00').valueOf(), testId: 'B' },
@@ -105,7 +105,7 @@ describe('shouldThrottle', () => {
     });
 
     it('returns false if epic was viewed too many times but test was not', () => {
-        const config = { days: 90, count: 4, minDaysBetweenViews: 5 };
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-07-11T10:24:00').valueOf(), testId: 'B' },

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -23,13 +23,13 @@ export const isRecentOneOffContributor = (
     return daysSince(lastOneOffContributionDate, now) <= pauseDays;
 };
 
-interface ThrottleConfig {
-    days: number;
-    count: number;
+export interface ThrottleConfig {
+    maxViewsDays: number;
+    maxViewsCount: number;
     minDaysBetweenViews: number;
 }
 
-const defaultThrottle = { days: 90, count: 4, minDaysBetweenViews: 5 };
+const defaultThrottle = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
 
 // Note, if testID is provided, will thottle against views only for that
 // specific test, otherwise will apply a global throttle.
@@ -45,10 +45,11 @@ export const shouldThrottle = (
         views = log.filter(view => view.testId === testId);
     }
 
-    const viewsInThrottleWindow = views.filter(
-        view => daysSince(new Date(view.date), now) <= config.days,
-    );
-    const exceedsViewsInWindow = viewsInThrottleWindow.length >= config.count;
+    const viewsInThrottleWindow = views.filter(view => {
+        return daysSince(new Date(view.date), now) <= config.maxViewsDays;
+    });
+
+    const exceedsViewsInWindow = viewsInThrottleWindow.length >= config.maxViewsCount;
     const withinMinDaysSinceLastView = viewsInThrottleWindow.some(
         view => daysSince(new Date(view.date), now) <= config.minDaysBetweenViews,
     );

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -76,7 +76,8 @@ describe('find variant', () => {
         const targeting = targetingDefault;
         const got = findVariant(tests, targeting);
 
-        expect(got?.name).toBe('control-example-1');
+        expect(got?.test.name).toBe('example-1');
+        expect(got?.variant.name).toBe('control-example-1');
     });
 
     it('should return undefined when no matching test variant', () => {
@@ -85,7 +86,7 @@ describe('find variant', () => {
         const targeting = { ...targetingDefault, sectionName: 'news' };
         const got = findVariant(tests, targeting);
 
-        expect(got?.name).toBe(undefined);
+        expect(got).toBe(undefined);
     });
 });
 

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -7,6 +7,7 @@ import {
     excludeSection,
     excludeTags,
     withinMaxViews,
+    isContentType,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 
@@ -228,5 +229,33 @@ describe('variant filters', () => {
 
         const got = filter.test(test1, targetingDefault);
         expect(got).toBe(true);
+    });
+
+    it('should filter by content type', () => {
+        const test1 = {
+            ...testDefault,
+            isLiveBlog: true,
+        };
+
+        const targeting1 = {
+            ...targetingDefault,
+            contentType: 'LiveBlog',
+        };
+
+        const got1 = isContentType.test(test1, targeting1);
+        expect(got1).toBe(true);
+
+        const test2 = {
+            ...testDefault,
+            isLiveBlog: true,
+        };
+
+        const targeting2 = {
+            ...targetingDefault,
+            contentType: 'Article',
+        };
+
+        const got2 = isContentType.test(test2, targeting2);
+        expect(got2).toBe(false);
     });
 });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -118,6 +118,11 @@ export const isOn: Filter = {
     test: (test, _) => test.isOn,
 };
 
+export const isContentType: Filter = {
+    id: 'isContentType',
+    test: (test, targeting) => (test.isLiveBlog ? targeting.contentType === 'LiveBlog' : true),
+};
+
 // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/experiments/ab-core.js#L39
 export const userInTest = (mvtId: number): Filter => ({
     id: 'userInTest',
@@ -170,6 +175,7 @@ export const findVariant = (
         excludeTags,
         hasCountryCode,
         withinMaxViews(log || []),
+        isContentType,
     ];
 
     const priorityOrdered = ([] as Test[]).concat(

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -113,6 +113,11 @@ export const excludeTags: Filter = {
     },
 };
 
+export const isOn: Filter = {
+    id: 'isOn',
+    test: (test, _) => test.isOn,
+};
+
 // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/experiments/ab-core.js#L39
 export const userInTest = (mvtId: number): Filter => ({
     id: 'userInTest',
@@ -157,6 +162,7 @@ export const findVariant = (
 
     // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L378
     const filters: Filter[] = [
+        isOn,
         hasSection,
         hasTags,
         userInTest(targeting.mvtId || 1),

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -148,7 +148,12 @@ export const findVariant = (data: EpicTests, targeting: EpicTargeting): Result |
         hasCountryCode,
     ];
 
-    const test = data.tests.find(test =>
+    const priorityOrdered = ([] as Test[]).concat(
+        data.tests.filter(test => test.highPriority),
+        data.tests.filter(test => !test.highPriority),
+    );
+
+    const test = priorityOrdered.find(test =>
         filters.every(filter => {
             const got = filter.test(test, targeting);
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -149,15 +149,17 @@ app.post(
             return;
         }
 
-        const { tracking, targeting, expectedVariant } = req.body;
+        const { targeting, expectedTest, expectedVariant } = req.body;
 
         const tests = await fetchConfiguredEpicTestsCached();
+
         const got = findVariant(tests, targeting);
 
-        if (got !== expectedVariant) {
+        // TODO logging the variant name is not useful, really we want the test + variant names(!)
+        if (got?.test.name !== expectedTest || got?.variant.name !== expectedVariant) {
             console.log(
-                `comparison failed: got (${got}, want (${expectedVariant}), for tracking data ${JSON.stringify(
-                    tracking,
+                `comparison failed: got (${`${got?.test.name}:${got?.variant.name}`}, want (${expectedTest}:${expectedVariant}), for targeting data ${JSON.stringify(
+                    targeting,
                 )})`,
             );
         }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -149,11 +149,9 @@ app.post(
             return;
         }
 
-        const { targeting, expectedTest, expectedVariant } = req.body;
-
+        const { targeting, expectedTest, expectedVariant, viewLog } = req.body;
         const tests = await fetchConfiguredEpicTestsCached();
-
-        const got = findVariant(tests, targeting);
+        const got = findVariant(tests, targeting, viewLog);
 
         // TODO logging the variant name is not useful, really we want the test + variant names(!)
         if (got?.test.name !== expectedTest || got?.variant.name !== expectedVariant) {


### PR DESCRIPTION
* dynamically fetch configured test JSON (with the usual caching)
* order tests by priority
* add some extra filters (max views, is on, content type check)
* other fixes/tidups to improve tests and also output of the comparison endpoint