### PR TITLE
Updating button colour shades

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate-schemas": "./src/scripts/validate-schema-updates.sh"
   },
   "dependencies": {
-    "@guardian/src-foundations": "^0.14.1",
+    "@guardian/src-foundations": "^0.14.2",
     "@storybook/addon-knobs": "^5.3.8",
     "@storybook/preset-typescript": "^1.2.0",
     "aws-serverless-express": "^3.3.6",

--- a/src/components/PrimaryButton.tsx
+++ b/src/components/PrimaryButton.tsx
@@ -7,7 +7,7 @@ import { space } from '@guardian/src-foundations';
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
 const linkStyles = css`
-    background: ${palette.brandAlt[400]};
+    background: ${palette.brandAlt.main};
     border-radius: 21px;
     box-sizing: border-box;
     color: ${palette.neutral[7]} !important;
@@ -20,7 +20,7 @@ const linkStyles = css`
     transition: background-color 0.3s ease-in-out;
 
     :hover {
-        background: ${palette.brandAlt[200]};
+        background: ${palette.brandAlt.dark};
         text-decoration: none;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,10 +1201,10 @@
     aws-sdk "^2.481.0"
     yaml "^1.7.2"
 
-"@guardian/src-foundations@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.14.1.tgz#33cf2e95eedf184fdfc40cc75c1dbca4d6d46fdf"
-  integrity sha512-FiH2nsPvHS6wG7b0AePXTGbDCIV+q0aRHZKhsH2X2WeS9K3fZqEF9y+8lTv22nW3r3sv6nSyh4tT7y5+XPC9pA==
+"@guardian/src-foundations@^0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.14.2.tgz#b1789edbb28099f5834ce8319401142a84500d59"
+  integrity sha512-e+yrYM2WRRb5C4BkJuGstTbaPTn7WS+TdKT2LoxwYBlXWSM3qrHOOFHCTc97uuEgT5E39GqzA/6oScrwmSr9BA==
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
Updates the Primary Button colours to use `main` and `dark` shades, as defined in the latest version of the Design System. 

Shade `200` used until now is no longer supported by the design system so we should adopt the new shades going forward.