### PR TITLE
Ignore comparisons where both are falsy

### DIFF
--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -136,10 +136,6 @@ export const ContributionsEpic: React.FC<Props> = ({ content, tracking, localisa
     const { heading, paragraphs, highlighted } = content;
     const { countryCode } = localisation;
 
-    if (countryCode !== 'GB') {
-        console.log('countryCode: ' + countryCode);
-    }
-
     // Get button URL with tracking params in query string
     const buttonBaseUrl = 'https://support.theguardian.com/uk/contribute';
     const buttonTrackingUrl = getTrackingUrl(buttonBaseUrl, tracking);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -153,8 +153,10 @@ app.post(
         const tests = await fetchConfiguredEpicTestsCached();
         const got = findVariant(tests, targeting, targeting.epicViewLog);
 
-        // TODO logging the variant name is not useful, really we want the test + variant names(!)
-        if (got?.test.name !== expectedTest || got?.variant.name !== expectedVariant) {
+        const notBothFalsy = expectedTest || got;
+        const notTheSame = got?.test.name !== expectedTest || got?.variant.name !== expectedVariant;
+
+        if (notBothFalsy && notTheSame) {
             console.log(
                 `comparison failed: got (${`${got?.test.name}:${got?.variant.name}`}, want (${expectedTest}:${expectedVariant}), for targeting data ${JSON.stringify(
                     targeting,


### PR DESCRIPTION
As it's not possible to send undefined in JSON explicitly let's just be broad in what we accept here and then ignore cases where both expected and actual are falsy (false, null, undefined, '', etc.). At the moment these cases appear in our logs as:

    comparison failed: got (undefined:undefined, want (:)

Also (separately) stop logging country code as no longer needed.