### PR TITLE
Tweaks Epic throttling conditions

### DIFF
--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -71,46 +71,49 @@ describe('shouldNotRenderEpic', () => {
 });
 
 describe('shouldThrottle', () => {
-    it('returns true if epic was viewed too recently', () => {
+    it('returns true if epic was viewed just now', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const viewLog = [{ date: new Date('2019-06-12T10:23:59').valueOf(), testId: 'A' }];
         const now = new Date('2019-06-12T10:24:00');
-
-        // Epic viewed just now
-        const viewLog1 = [{ date: new Date('2019-06-12T10:23:59').valueOf(), testId: 'A' }];
-        const got1 = shouldThrottle(viewLog1, config, undefined, now);
-        expect(got1).toBe(true);
-
-        // Epic viewed yesterday
-        const viewLog2 = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
-        const got2 = shouldThrottle(viewLog2, config, undefined, now);
-        expect(got2).toBe(true);
-
-        // Epic viewed nearly 2 days ago
-        const viewLog3 = [{ date: new Date('2019-06-10T10:24:01').valueOf(), testId: 'A' }];
-        const got3 = shouldThrottle(viewLog3, config, undefined, now);
-        expect(got3).toBe(true);
+        const got = shouldThrottle(viewLog, config, undefined, now);
+        expect(got).toBe(true);
     });
 
-    it('returns false if epic was not viewed too recently', () => {
+    it('returns true if epic was viewed yesterday', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const viewLog = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
         const now = new Date('2019-06-12T10:24:00');
-
-        // Epic viewed 2 days ago
-        const viewLog1 = [{ date: new Date('2019-06-10T10:24:00').valueOf(), testId: 'A' }];
-        const got1 = shouldThrottle(viewLog1, config, undefined, now);
-        expect(got1).toBe(false);
-
-        // Epic viewed longer ago
-        const viewLog2 = [{ date: new Date('2019-06-01T10:24:00').valueOf(), testId: 'A' }];
-        const got2 = shouldThrottle(viewLog2, config, undefined, now);
-        expect(got2).toBe(false);
+        const got = shouldThrottle(viewLog, config, undefined, now);
+        expect(got).toBe(true);
     });
 
-    it('returns true if epic was viewed too many times', () => {
+    it('returns true if epic was viewed nearly 2 days ago', () => {
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const viewLog = [{ date: new Date('2019-06-10T10:24:01').valueOf(), testId: 'A' }];
+        const now = new Date('2019-06-12T10:24:00');
+        const got = shouldThrottle(viewLog, config, undefined, now);
+        expect(got).toBe(true);
+    });
+
+    it('returns false if epic was viewed 2 days ago', () => {
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const viewLog = [{ date: new Date('2019-06-10T10:24:00').valueOf(), testId: 'A' }];
+        const now = new Date('2019-06-12T10:24:00');
+        const got = shouldThrottle(viewLog, config, undefined, now);
+        expect(got).toBe(false);
+    });
+
+    it('returns false if epic was viewed longer than 2 days ago', () => {
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const viewLog = [{ date: new Date('2019-06-01T10:24:00').valueOf(), testId: 'A' }];
+        const now = new Date('2019-06-12T10:24:00');
+        const got = shouldThrottle(viewLog, config, undefined, now);
+        expect(got).toBe(false);
+    });
+
+    it('returns true if epic was viewed just above the max number of times', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const now = new Date('2019-07-09T10:24:00');
-
-        // Just above the max number of views for this Epic
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-06-12T10:24:00').valueOf(), testId: 'B' },
@@ -123,11 +126,9 @@ describe('shouldThrottle', () => {
         expect(got).toBe(true);
     });
 
-    it('returns false if epic was not viewed too many times', () => {
+    it('returns false if epic was viewed exactly the max number of times', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const now = new Date('2019-07-09T10:24:00');
-
-        // Exactly at the max number of views for this Epic
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-06-12T10:24:00').valueOf(), testId: 'B' },

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -126,7 +126,7 @@ describe('shouldThrottle', () => {
         expect(got).toBe(true);
     });
 
-    it('returns false if epic was viewed exactly the max number of times', () => {
+    it('returns true if epic has reached the max number of views', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const now = new Date('2019-07-09T10:24:00');
         const viewLog = [
@@ -137,7 +137,7 @@ describe('shouldThrottle', () => {
             { date: new Date('2019-06-15T10:24:00').valueOf(), testId: 'A' },
         ];
         const got = shouldThrottle(viewLog, config, 'A', now);
-        expect(got).toBe(false);
+        expect(got).toBe(true);
     });
 
     it('returns false if epic was viewed too many times even though test was not', () => {
@@ -148,7 +148,6 @@ describe('shouldThrottle', () => {
             { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'B' },
             { date: new Date('2019-08-11T10:24:00').valueOf(), testId: 'A' },
-            { date: new Date('2019-08-12T10:24:00').valueOf(), testId: 'A' },
         ];
 
         const now = new Date('2019-09-01T10:24:00');

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -72,39 +72,74 @@ describe('shouldNotRenderEpic', () => {
 
 describe('shouldThrottle', () => {
     it('returns true if epic was viewed too recently', () => {
-        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
-        const viewLog = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
-
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
         const now = new Date('2019-06-12T10:24:00');
-        const got = shouldThrottle(viewLog, config, undefined, now);
-        expect(got).toBe(true);
+
+        // Epic viewed just now
+        const viewLog1 = [{ date: new Date('2019-06-12T10:23:59').valueOf(), testId: 'A' }];
+        const got1 = shouldThrottle(viewLog1, config, undefined, now);
+        expect(got1).toBe(true);
+
+        // Epic viewed yesterday
+        const viewLog2 = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
+        const got2 = shouldThrottle(viewLog2, config, undefined, now);
+        expect(got2).toBe(true);
+
+        // Epic viewed nearly 2 days ago
+        const viewLog3 = [{ date: new Date('2019-06-10T10:24:01').valueOf(), testId: 'A' }];
+        const got3 = shouldThrottle(viewLog3, config, undefined, now);
+        expect(got3).toBe(true);
     });
 
     it('returns false if epic was not viewed too recently', () => {
-        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
-        const viewLog = [{ date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' }];
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 2 };
+        const now = new Date('2019-06-12T10:24:00');
 
-        const now = new Date('2019-06-17T10:24:00');
-        const got = shouldThrottle(viewLog, config, undefined, now);
-        expect(got).toBe(false);
+        // Epic viewed 2 days ago
+        const viewLog1 = [{ date: new Date('2019-06-10T10:24:00').valueOf(), testId: 'A' }];
+        const got1 = shouldThrottle(viewLog1, config, undefined, now);
+        expect(got1).toBe(false);
+
+        // Epic viewed longer ago
+        const viewLog2 = [{ date: new Date('2019-06-01T10:24:00').valueOf(), testId: 'A' }];
+        const got2 = shouldThrottle(viewLog2, config, undefined, now);
+        expect(got2).toBe(false);
     });
 
     it('returns true if epic was viewed too many times', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
+        const now = new Date('2019-07-09T10:24:00');
+
+        // Just above the max number of views for this Epic
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
-            { date: new Date('2019-07-11T10:24:00').valueOf(), testId: 'B' },
-            { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'A' },
-            { date: new Date('2019-07-17T10:24:00').valueOf(), testId: 'A' },
-            { date: new Date('2019-08-11T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-12T10:24:00').valueOf(), testId: 'B' },
+            { date: new Date('2019-06-13T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-14T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-15T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-16T10:24:00').valueOf(), testId: 'A' },
         ];
-
-        const now = new Date('2019-09-01T10:24:00');
         const got = shouldThrottle(viewLog, config, 'A', now);
         expect(got).toBe(true);
     });
 
-    it('returns false if epic was viewed too many times but test was not', () => {
+    it('returns false if epic was not viewed too many times', () => {
+        const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
+        const now = new Date('2019-07-09T10:24:00');
+
+        // Exactly at the max number of views for this Epic
+        const viewLog = [
+            { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-12T10:24:00').valueOf(), testId: 'B' },
+            { date: new Date('2019-06-13T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-14T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-06-15T10:24:00').valueOf(), testId: 'A' },
+        ];
+        const got = shouldThrottle(viewLog, config, 'A', now);
+        expect(got).toBe(false);
+    });
+
+    it('returns false if epic was viewed too many times even though test was not', () => {
         const config = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'A' },
@@ -112,6 +147,7 @@ describe('shouldThrottle', () => {
             { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'A' },
             { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'B' },
             { date: new Date('2019-08-11T10:24:00').valueOf(), testId: 'A' },
+            { date: new Date('2019-08-12T10:24:00').valueOf(), testId: 'A' },
         ];
 
         const now = new Date('2019-09-01T10:24:00');

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -29,8 +29,6 @@ export interface ThrottleConfig {
     minDaysBetweenViews: number;
 }
 
-const defaultThrottle = { maxViewsDays: 90, maxViewsCount: 4, minDaysBetweenViews: 5 };
-
 // Note, if testID is provided, will thottle against views only for that
 // specific test, otherwise will apply a global throttle.
 export const shouldThrottle = (
@@ -46,10 +44,10 @@ export const shouldThrottle = (
     }
 
     const viewsInThrottleWindow = views.filter(view => {
-        return daysSince(new Date(view.date), now) <= config.maxViewsDays;
+        return daysSince(new Date(view.date), now) < config.maxViewsDays;
     });
 
-    const exceedsViewsInWindow = viewsInThrottleWindow.length >= config.maxViewsCount;
+    const exceedsViewsInWindow = viewsInThrottleWindow.length > config.maxViewsCount;
 
     const withinMinDaysSinceLastView = viewsInThrottleWindow.some(
         view => daysSince(new Date(view.date), now) < config.minDaysBetweenViews,

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -47,13 +47,13 @@ export const shouldThrottle = (
         return daysSince(new Date(view.date), now) < config.maxViewsDays;
     });
 
-    const exceedsViewsInWindow = viewsInThrottleWindow.length > config.maxViewsCount;
+    const hasReachedViewsLimitInWindow = viewsInThrottleWindow.length >= config.maxViewsCount;
 
     const withinMinDaysSinceLastView = viewsInThrottleWindow.some(
         view => daysSince(new Date(view.date), now) < config.minDaysBetweenViews,
     );
 
-    return exceedsViewsInWindow || withinMinDaysSinceLastView;
+    return hasReachedViewsLimitInWindow || withinMinDaysSinceLastView;
 };
 
 export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -50,8 +50,9 @@ export const shouldThrottle = (
     });
 
     const exceedsViewsInWindow = viewsInThrottleWindow.length >= config.maxViewsCount;
+
     const withinMinDaysSinceLastView = viewsInThrottleWindow.some(
-        view => daysSince(new Date(view.date), now) <= config.minDaysBetweenViews,
+        view => daysSince(new Date(view.date), now) < config.minDaysBetweenViews,
     );
 
     return exceedsViewsInWindow || withinMinDaysSinceLastView;


### PR DESCRIPTION
Tweaks the throttling conditions to reflect the fact that counting days between dates always starts at zero days.
This should fix some of our failed comparison errors.