### PR TITLE
Ignore our own manual test for comparison logging

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -151,6 +151,13 @@ app.post(
         }
 
         const { targeting, expectedTest, expectedVariant } = req.body;
+
+        // This is our own test(!) so can ignore
+        if (expectedTest === 'RemoteRenderEpicRoundTwo') {
+            res.send('ignoring');
+            return;
+        }
+
         const tests = await fetchConfiguredEpicTestsCached();
         const got = findVariant(tests, targeting, targeting.epicViewLog);
 


### PR DESCRIPTION
Initially I thought we need to support the existing manual tests in DCR but that is not true because:

* one of them (RemoteRenderEpicRoundTwo) is our own test
* the other (ContributionsEpicAskFourEarning) never gets called from what I can tell

If the second proves untrue, we can revisit.

But for now, I've just updated the comparison endpoint to ignore cases of our own test.

https://trello.com/c/4CxCisjn/73-support-manually-defined-tests