### PR TITLE
Refactor ContributionsEpic to take a Variant

### DIFF
--- a/src/api/contributionsApi.test.ts
+++ b/src/api/contributionsApi.test.ts
@@ -41,9 +41,11 @@ describe('fetchDefaultEpic', () => {
         const epicData = await fetchData();
 
         expect(epicData).toEqual({
+            name: 'remote_epic_test',
+            showTicker: false,
             heading: 'Since you’re here...',
             paragraphs: ['First paragraph', 'Second paragraph'],
-            highlighted: ['Highlighted Text'],
+            highlightedText: 'Highlighted Text',
         });
     });
 

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -1,18 +1,12 @@
 import fetch from 'node-fetch';
-import { EpicTests } from '../lib/variants';
+import { EpicTests, Variant } from '../lib/variants';
 
 const defaultEpicUrl =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 
 const configuredTestsUrl = 'https://support.theguardian.com/epic-tests.json';
 
-export type DefaultEpicContent = {
-    heading?: string;
-    paragraphs: string[];
-    highlighted: string[];
-};
-
-export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => {
+export const fetchDefaultEpicContent = async (): Promise<Variant> => {
     const startTime = new Date().getTime();
 
     const response = await fetch(defaultEpicUrl);
@@ -24,11 +18,14 @@ export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => 
     const data = await response.json();
     const control = data?.sheets?.control;
 
+    const emptyVariant = {
+        paragraphs: [],
+        showTicker: false,
+        name: 'remote_epic_test',
+    };
+
     const transformedData = control.reduce(
-        (
-            acc: DefaultEpicContent,
-            item: { heading: string; paragraphs: string; highlightedText: string },
-        ) => {
+        (acc: Variant, item: { heading: string; paragraphs: string; highlightedText: string }) => {
             if (!acc.heading && item.heading) {
                 acc.heading = item.heading;
             }
@@ -36,11 +33,11 @@ export const fetchDefaultEpicContent = async (): Promise<DefaultEpicContent> => 
                 acc.paragraphs.push(item.paragraphs);
             }
             if (item.highlightedText) {
-                acc.highlighted.push(item.highlightedText);
+                acc.highlightedText = acc.highlightedText || item.highlightedText;
             }
             return acc;
         },
-        { paragraphs: [], highlighted: [] },
+        emptyVariant,
     );
 
     const endTime = new Date().getTime();

--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -3,6 +3,7 @@ import { ContributionsEpic } from './ContributionsEpic';
 import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import testData from './ContributionsEpic.testData';
+import { Variant } from '../lib/variants';
 
 export default {
     component: ContributionsEpic,
@@ -12,10 +13,12 @@ export default {
 
 export const defaultStory = (): ReactElement => {
     // Epic content props
-    const epicContent = {
+    const variant: Variant = {
+        name: 'Test Epic',
         heading: text('heading', testData.content.heading),
         paragraphs: object('paragraphs', testData.content.paragraphs),
-        highlighted: object('highlighted', testData.content.highlighted),
+        highlightedText: text('highlightedText', testData.content.highlightedText),
+        showTicker: false,
     };
 
     // Epic metadata props
@@ -37,7 +40,7 @@ export const defaultStory = (): ReactElement => {
     return (
         <StorybookWrapper>
             <ContributionsEpic
-                content={epicContent}
+                variant={variant}
                 tracking={epicTracking}
                 localisation={epicLocalisation}
             />

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -8,9 +8,8 @@ const content = {
         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
         'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
     ],
-    highlighted: [
+    highlightedText:
         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
-    ],
 };
 
 const tracking: EpicTracking = {

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -7,6 +7,7 @@ import { PrimaryButton } from './PrimaryButton';
 import { getTrackingUrl } from '../lib/tracking';
 import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicLocalisation, EpicTracking } from './ContributionsEpicTypes';
+import { Variant } from '../lib/variants';
 
 const replacePlaceholders = (content: string, countryCode?: string): string => {
     // Replace currency symbol placeholder with actual currency symbol
@@ -72,68 +73,61 @@ const imageStyles = css`
     margin: ${space[1]}px 0;
 `;
 
-export type EpicContent = {
-    heading?: string;
-    paragraphs: string[];
-    highlighted: string[];
-    countryCode?: string;
-};
-
 export type Props = {
-    content: EpicContent;
+    variant: Variant;
     tracking: EpicTracking;
     localisation: EpicLocalisation;
 };
 
 type HighlightedProps = {
-    highlighted: string[];
+    highlightedText: string;
     countryCode?: string;
 };
 
 type BodyProps = {
-    paragraphs: string[];
-    highlighted: string[];
+    variant: Variant;
     countryCode?: string;
 };
 
 const Highlighted: React.FC<HighlightedProps> = ({
-    highlighted,
+    highlightedText,
     countryCode,
 }: HighlightedProps) => (
     <strong className={highlightWrapperStyles}>
         {' '}
-        {highlighted.map((highlightText, idx) => (
-            <span
-                key={idx}
-                className={highlightStyles}
-                dangerouslySetInnerHTML={{
-                    __html: replacePlaceholders(highlightText, countryCode),
-                }}
-            />
-        ))}
+        <span
+            className={highlightStyles}
+            dangerouslySetInnerHTML={{
+                __html: replacePlaceholders(highlightedText, countryCode),
+            }}
+        />
     </strong>
 );
 
-const EpicBody: React.FC<BodyProps> = ({ highlighted, paragraphs, countryCode }: BodyProps) => (
-    <>
-        {paragraphs.map((paragraph, idx) => (
-            <p key={idx} className={bodyStyles}>
-                <span
-                    dangerouslySetInnerHTML={{
-                        __html: replacePlaceholders(paragraph, countryCode),
-                    }}
-                />
+const EpicBody: React.FC<BodyProps> = ({ variant, countryCode }: BodyProps) => {
+    const { paragraphs, highlightedText } = variant;
 
-                {highlighted.length > 0 && idx === paragraphs.length - 1 && (
-                    <Highlighted highlighted={highlighted} countryCode={countryCode} />
-                )}
-            </p>
-        ))}
-    </>
-);
+    return (
+        <>
+            {paragraphs.map((paragraph, idx) => (
+                <p key={idx} className={bodyStyles}>
+                    <span
+                        dangerouslySetInnerHTML={{
+                            __html: replacePlaceholders(paragraph, countryCode),
+                        }}
+                    />
 
-export const ContributionsEpic: React.FC<Props> = ({ content, tracking, localisation }: Props) => {
-    const { heading, paragraphs, highlighted } = content;
+                    {highlightedText && idx === paragraphs.length - 1 && (
+                        <Highlighted highlightedText={highlightedText} countryCode={countryCode} />
+                    )}
+                </p>
+            ))}
+        </>
+    );
+};
+
+export const ContributionsEpic: React.FC<Props> = ({ variant, tracking, localisation }: Props) => {
+    const { heading } = variant;
     const { countryCode } = localisation;
 
     // Get button URL with tracking params in query string
@@ -149,7 +143,7 @@ export const ContributionsEpic: React.FC<Props> = ({ content, tracking, localisa
                 />
             )}
 
-            <EpicBody paragraphs={paragraphs} highlighted={highlighted} countryCode={countryCode} />
+            <EpicBody variant={variant} countryCode={countryCode} />
 
             <div className={buttonWrapperStyles}>
                 <PrimaryButton url={buttonTrackingUrl} linkText="Support The Guardian" />

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -18,7 +18,7 @@ interface Cta {
     baseUrl: string;
 }
 
-interface Variant {
+export interface Variant {
     name: string;
     heading?: string;
     paragraphs: string[];

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -68,12 +68,7 @@ const buildEpic = async (
     localisation: EpicLocalisation,
     targeting: EpicTargeting,
 ): Promise<Epic | null> => {
-    const { heading, paragraphs, highlighted } = await fetchDefaultEpicContentCached();
-    const content = {
-        heading,
-        paragraphs,
-        highlighted,
-    };
+    const variant = await fetchDefaultEpicContentCached();
 
     // Only log for now - as Frontend does this and we may have bugs
     // We'll need to do more than log when we start our DCR test though
@@ -83,7 +78,7 @@ const buildEpic = async (
 
     const { html, css } = extractCritical(
         renderToStaticMarkup(
-            <ContributionsEpic content={content} tracking={tracking} localisation={localisation} />,
+            <ContributionsEpic variant={variant} tracking={tracking} localisation={localisation} />,
         ),
     );
     return { html, css };


### PR DESCRIPTION
This is in preparation for the ongoing variants work. Rework the default epic content fetch to return a Variant. The current default epic, as it appears to the user, should be unchanged (maybe this is a rare use case for adding a snapshot test?!)