### PR TITLE
Include article viewed settings in variant checks

### DIFF
--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -4,6 +4,7 @@ import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import testData from './ContributionsEpic.testData';
 import { Variant } from '../lib/variants';
+import { getArticleViewCountForWeeks } from '../lib/history';
 
 export default {
     component: ContributionsEpic,
@@ -37,12 +38,21 @@ export const defaultStory = (): ReactElement => {
         countryCode: text('countryCode', testData.localisation.countryCode || 'GB'),
     };
 
+    // Number of articles viewed
+    // Used to replace the template placeholder
+    const periodInWeeks = 52;
+    const numArticles = getArticleViewCountForWeeks(
+        testData.targeting.weeklyArticleHistory,
+        periodInWeeks,
+    );
+
     return (
         <StorybookWrapper>
             <ContributionsEpic
                 variant={variant}
                 tracking={epicTracking}
                 localisation={epicLocalisation}
+                numArticles={numArticles}
             />
         </StorybookWrapper>
     );

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -59,6 +59,10 @@ const targeting: EpicTargeting = {
     isRecurringContributor: false,
     lastOneOffContributionDate: 1548979200000, // 2019-02-01
     mvtId: 2,
+    weeklyArticleHistory: [
+        { week: 18337, count: 10 },
+        { week: 18330, count: 5 },
+    ],
 };
 
 const testData = { content, tracking, localisation, targeting };

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -9,10 +9,18 @@ import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicLocalisation, EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../lib/variants';
 
-const replacePlaceholders = (content: string, countryCode?: string): string => {
+const replacePlaceholders = (
+    content: string,
+    numArticles: number,
+    countryCode?: string,
+): string => {
     // Replace currency symbol placeholder with actual currency symbol
     // Function uses default currency symbol so countryCode is not strictly required here
     content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
+
+    // Replace number of viewed articles
+    // Value could be zero but we'll replace anyway
+    content = content.replace(/%%ARTICLE_COUNT%%/g, numArticles.toString());
 
     // Replace country code placeholder with actual country name
     // Should only replace if we were able to determine the country name from country code
@@ -77,34 +85,38 @@ export type Props = {
     variant: Variant;
     tracking: EpicTracking;
     localisation: EpicLocalisation;
+    numArticles: number;
 };
 
 type HighlightedProps = {
     highlightedText: string;
     countryCode?: string;
+    numArticles: number;
 };
 
 type BodyProps = {
     variant: Variant;
     countryCode?: string;
+    numArticles: number;
 };
 
 const Highlighted: React.FC<HighlightedProps> = ({
     highlightedText,
     countryCode,
+    numArticles,
 }: HighlightedProps) => (
     <strong className={highlightWrapperStyles}>
         {' '}
         <span
             className={highlightStyles}
             dangerouslySetInnerHTML={{
-                __html: replacePlaceholders(highlightedText, countryCode),
+                __html: replacePlaceholders(highlightedText, numArticles, countryCode),
             }}
         />
     </strong>
 );
 
-const EpicBody: React.FC<BodyProps> = ({ variant, countryCode }: BodyProps) => {
+const EpicBody: React.FC<BodyProps> = ({ variant, countryCode, numArticles }: BodyProps) => {
     const { paragraphs, highlightedText } = variant;
 
     return (
@@ -113,12 +125,16 @@ const EpicBody: React.FC<BodyProps> = ({ variant, countryCode }: BodyProps) => {
                 <p key={idx} className={bodyStyles}>
                     <span
                         dangerouslySetInnerHTML={{
-                            __html: replacePlaceholders(paragraph, countryCode),
+                            __html: replacePlaceholders(paragraph, numArticles, countryCode),
                         }}
                     />
 
                     {highlightedText && idx === paragraphs.length - 1 && (
-                        <Highlighted highlightedText={highlightedText} countryCode={countryCode} />
+                        <Highlighted
+                            highlightedText={highlightedText}
+                            countryCode={countryCode}
+                            numArticles={numArticles}
+                        />
                     )}
                 </p>
             ))}
@@ -126,7 +142,12 @@ const EpicBody: React.FC<BodyProps> = ({ variant, countryCode }: BodyProps) => {
     );
 };
 
-export const ContributionsEpic: React.FC<Props> = ({ variant, tracking, localisation }: Props) => {
+export const ContributionsEpic: React.FC<Props> = ({
+    variant,
+    tracking,
+    localisation,
+    numArticles,
+}: Props) => {
     const { heading } = variant;
     const { countryCode } = localisation;
 
@@ -139,11 +160,13 @@ export const ContributionsEpic: React.FC<Props> = ({ variant, tracking, localisa
             {heading && (
                 <h2
                     className={headingStyles}
-                    dangerouslySetInnerHTML={{ __html: replacePlaceholders(heading, countryCode) }}
+                    dangerouslySetInnerHTML={{
+                        __html: replacePlaceholders(heading, numArticles, countryCode),
+                    }}
                 />
             )}
 
-            <EpicBody variant={variant} countryCode={countryCode} />
+            <EpicBody variant={variant} countryCode={countryCode} numArticles={numArticles} />
 
             <div className={buttonWrapperStyles}>
                 <PrimaryButton url={buttonTrackingUrl} linkText="Support The Guardian" />

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -23,6 +23,13 @@ interface View {
 }
 export type ViewLog = View[];
 
+export type WeeklyArticleLog = {
+    week: number;
+    count: number;
+};
+
+export type WeeklyArticleHistory = WeeklyArticleLog[];
+
 export type EpicTargeting = {
     contentType: string;
     sectionName: string;
@@ -36,6 +43,7 @@ export type EpicTargeting = {
     mvtId?: number;
     epicViewLog?: ViewLog;
     countryCode?: string;
+    weeklyArticleHistory?: WeeklyArticleHistory;
 
     // Note, it turns out that showSupportMessaging (defined in the Members Data
     // API) does not capture every case of recurring contributors or last

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -1,0 +1,55 @@
+import { getMondayFromDate, getArticleViewCountForWeeks } from './history';
+
+const oneDay = 86400000;
+
+describe('getMondayFromDate', () => {
+    it('should return Monday midnight if today is Monday', () => {
+        const mondayMorning = new Date('2020-03-02T09:15:30');
+        const mondayMidnight = Math.floor(mondayMorning.getTime() / oneDay);
+
+        const mondayEvening = new Date('2020-03-02T19:25:00');
+        const got = getMondayFromDate(mondayEvening);
+        expect(got).toBe(mondayMidnight);
+    });
+
+    it('should return Monday midnight if today is some other day', () => {
+        const mondayMorning = new Date('2020-03-02T09:15:30');
+        const mondayMidnight = Math.floor(mondayMorning.getTime() / oneDay);
+
+        const fridayAfternoon = new Date('2020-03-06T16:35:00');
+        const got = getMondayFromDate(fridayAfternoon);
+        expect(got).toBe(mondayMidnight);
+    });
+});
+
+describe('getArticleViewCountForWeeks', () => {
+    it('should count views for one week properly', () => {
+        const history = [{ week: 18330, count: 45 }];
+        const numWeeks = 1;
+        const got = getArticleViewCountForWeeks(history, numWeeks);
+        expect(got).toBe(45);
+    });
+
+    it('should count views for several weeks properly', () => {
+        const history = [
+            { week: 18330, count: 15 },
+            { week: 18323, count: 5 },
+            { week: 18316, count: 5 },
+        ];
+        const numWeeks = 3;
+        const got = getArticleViewCountForWeeks(history, numWeeks);
+        expect(got).toBe(25);
+    });
+
+    it('should not count views for all weeks in the history object', () => {
+        const history = [
+            { week: 18330, count: 15 },
+            { week: 18323, count: 5 },
+            { week: 18316, count: 5 },
+            { week: 18309, count: 5 }, // not be be included as we only want 3 weeks
+        ];
+        const numWeeks = 3;
+        const got = getArticleViewCountForWeeks(history, numWeeks);
+        expect(got).toBe(25);
+    });
+});

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -4,21 +4,19 @@ const oneDay = 86400000;
 
 describe('getMondayFromDate', () => {
     it('should return Monday midnight if today is Monday', () => {
-        const mondayMorning = new Date('2020-03-02T09:15:30');
-        const mondayMidnight = Math.floor(mondayMorning.getTime() / oneDay);
-
+        const mondayMidnight = new Date('2020-03-02T00:00:00');
         const mondayEvening = new Date('2020-03-02T19:25:00');
+
         const got = getMondayFromDate(mondayEvening);
-        expect(got).toBe(mondayMidnight);
+        expect(got).toBe(mondayMidnight.getTime() / oneDay);
     });
 
     it('should return Monday midnight if today is some other day', () => {
-        const mondayMorning = new Date('2020-03-02T09:15:30');
-        const mondayMidnight = Math.floor(mondayMorning.getTime() / oneDay);
-
+        const mondayMidnight = new Date('2020-03-02T00:00:00');
         const fridayAfternoon = new Date('2020-03-06T16:35:00');
+
         const got = getMondayFromDate(fridayAfternoon);
-        expect(got).toBe(mondayMidnight);
+        expect(got).toBe(mondayMidnight.getTime() / oneDay);
     });
 });
 

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -21,10 +21,14 @@ describe('getMondayFromDate', () => {
 });
 
 describe('getArticleViewCountForWeeks', () => {
+    // Pass the current date into the tested function so the checks can be made
+    // against a fixed date.
+    const rightNow = new Date('2020-03-16T09:30:00');
+
     it('should count views for one week properly', () => {
         const history = [{ week: 18330, count: 45 }];
         const numWeeks = 1;
-        const got = getArticleViewCountForWeeks(history, numWeeks);
+        const got = getArticleViewCountForWeeks(history, numWeeks, rightNow);
         expect(got).toBe(45);
     });
 
@@ -35,7 +39,7 @@ describe('getArticleViewCountForWeeks', () => {
             { week: 18316, count: 5 },
         ];
         const numWeeks = 3;
-        const got = getArticleViewCountForWeeks(history, numWeeks);
+        const got = getArticleViewCountForWeeks(history, numWeeks, rightNow);
         expect(got).toBe(25);
     });
 
@@ -47,7 +51,7 @@ describe('getArticleViewCountForWeeks', () => {
             { week: 18309, count: 5 }, // not be be included as we only want 3 weeks
         ];
         const numWeeks = 3;
-        const got = getArticleViewCountForWeeks(history, numWeeks);
+        const got = getArticleViewCountForWeeks(history, numWeeks, rightNow);
         expect(got).toBe(25);
     });
 });

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -11,8 +11,9 @@ export const getMondayFromDate = (date: Date): number => {
 export const getArticleViewCountForWeeks = (
     history: WeeklyArticleHistory = [],
     weeks: number,
+    rightNow: Date = new Date(),
 ): number => {
-    const mondayThisWeek = getMondayFromDate(new Date());
+    const mondayThisWeek = getMondayFromDate(rightNow);
     const cutOffWeek = mondayThisWeek - weeks * 7;
 
     // Filter only weeks within cutoff period

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,29 @@
+import { WeeklyArticleLog, WeeklyArticleHistory } from '../components/ContributionsEpicTypes';
+
+export const getMondayFromDate = (date: Date): number => {
+    const day = date.getDay() || 7;
+    if (day !== 1) {
+        date.setHours(-24 * (day - 1));
+    }
+    return Math.floor(date.getTime() / 86400000);
+};
+
+export const getArticleViewCountForWeeks = (
+    history: WeeklyArticleHistory = [],
+    weeks: number,
+): number => {
+    const mondayThisWeek = getMondayFromDate(new Date());
+    const cutOff = mondayThisWeek - weeks * 7;
+
+    const firstOldWeekIndex = history.findIndex(
+        (c: WeeklyArticleLog) => c.week && c.week <= cutOff,
+    );
+
+    const articleCountWindow =
+        firstOldWeekIndex >= 0 ? history.slice(0, firstOldWeekIndex) : history;
+
+    return articleCountWindow.reduce(
+        (accumulator: number, currentValue: WeeklyArticleLog) => currentValue.count + accumulator,
+        0,
+    );
+};

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -13,16 +13,14 @@ export const getArticleViewCountForWeeks = (
     weeks: number,
 ): number => {
     const mondayThisWeek = getMondayFromDate(new Date());
-    const cutOff = mondayThisWeek - weeks * 7;
+    const cutOffWeek = mondayThisWeek - weeks * 7;
 
-    const firstOldWeekIndex = history.findIndex(
-        (c: WeeklyArticleLog) => c.week && c.week <= cutOff,
+    // Filter only weeks within cutoff period
+    const weeksInWindow = history.filter(
+        (weeklyArticleLog: WeeklyArticleLog) => weeklyArticleLog.week >= cutOffWeek,
     );
 
-    const articleCountWindow =
-        firstOldWeekIndex >= 0 ? history.slice(0, firstOldWeekIndex) : history;
-
-    return articleCountWindow.reduce(
+    return weeksInWindow.reduce(
         (accumulator: number, currentValue: WeeklyArticleLog) => currentValue.count + accumulator,
         0,
     );

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -155,9 +155,9 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
 
 export const withinArticleViewedSettings = (history: WeeklyArticleHistory): Filter => ({
     id: 'withinArticleViewedSettings',
-    test: (test): boolean => {
+    test: (test, _): boolean => {
         // Allow test to pass if no articles viewed settings have been set
-        if (!test.articlesViewedSettings || test.articlesViewedSettings.periodInWeeks) {
+        if (!test.articlesViewedSettings || !test.articlesViewedSettings.periodInWeeks) {
             return true;
         }
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -181,11 +181,7 @@ interface Result {
     variant: Variant;
 }
 
-export const findVariant = (
-    data: EpicTests,
-    targeting: EpicTargeting,
-    // log?: ViewLog,
-): Result | undefined => {
+export const findVariant = (data: EpicTests, targeting: EpicTargeting): Result | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,5 +1,6 @@
-import { EpicTargeting, ViewLog } from '../components/ContributionsEpicTypes';
+import { EpicTargeting, ViewLog, WeeklyArticleHistory } from '../components/ContributionsEpicTypes';
 import { shouldThrottle, shouldNotRenderEpic } from '../lib/targeting';
+import { getArticleViewCountForWeeks } from '../lib/history';
 
 interface ArticlesViewedSettings {
     minViews: number;
@@ -152,6 +153,24 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
     },
 });
 
+export const withinArticleViewedSettings = (history: WeeklyArticleHistory): Filter => ({
+    id: 'withinArticleViewedSettings',
+    test: (test): boolean => {
+        // Allow test to pass if no articles viewed settings have been set
+        if (!test.articlesViewedSettings || test.articlesViewedSettings.periodInWeeks) {
+            return true;
+        }
+
+        const { minViews, maxViews, periodInWeeks } = test.articlesViewedSettings;
+
+        const viewCountForWeeks = getArticleViewCountForWeeks(history, periodInWeeks);
+        const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;
+        const maxViewsOk = maxViews ? viewCountForWeeks <= maxViews : true;
+
+        return minViewsOk && maxViewsOk;
+    },
+});
+
 export const shouldNotRender: Filter = {
     id: 'shouldNotRender',
     test: (_, targeting) => !shouldNotRenderEpic(targeting),
@@ -165,7 +184,7 @@ interface Result {
 export const findVariant = (
     data: EpicTests,
     targeting: EpicTargeting,
-    log?: ViewLog,
+    // log?: ViewLog,
 ): Result | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
@@ -180,7 +199,8 @@ export const findVariant = (
         excludeSection,
         excludeTags,
         hasCountryCode,
-        withinMaxViews(log || []),
+        withinMaxViews(targeting.epicViewLog || []),
+        withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
         isContentType,
     ];
 

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -92,6 +92,21 @@
                 "countryCode": {
                     "type": "string"
                 },
+                "weeklyArticleHistory": {
+                    "type": "object",
+                    "properties": {
+                        "week": {
+                            "type": "number"
+                        },
+                        "count": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "count",
+                        "week"
+                    ]
+                },
                 "showSupportMessaging": {
                     "type": "boolean"
                 },

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -93,19 +93,22 @@
                     "type": "string"
                 },
                 "weeklyArticleHistory": {
-                    "type": "object",
-                    "properties": {
-                        "week": {
-                            "type": "number"
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "week": {
+                                "type": "number"
+                            },
+                            "count": {
+                                "type": "number"
+                            }
                         },
-                        "count": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "count",
-                        "week"
-                    ]
+                        "required": [
+                            "count",
+                            "week"
+                        ]
+                    }
                 },
                 "showSupportMessaging": {
                     "type": "boolean"

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -21,6 +21,7 @@ import { Validator } from 'jsonschema';
 import * as fs from 'fs';
 import * as path from 'path';
 import { findVariant } from './lib/variants';
+import { getArticleViewCountForWeeks } from './lib/history';
 
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
@@ -76,9 +77,22 @@ const buildEpic = async (
         console.log(`Should not render for targeting data: ${JSON.stringify(targeting)}`);
     }
 
+    // Hardcoding the number of weeks to match common values used in the tests.
+    // We know the copy refers to 'articles viewed in past 4 months' and this
+    // will show a count for the past year, but this seems to mirror Frontend
+    // and an accurate match between the view counts used for variant selection
+    // and template rendering is not necessarily essential.
+    const periodInWeeks = 52;
+    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory, periodInWeeks);
+
     const { html, css } = extractCritical(
         renderToStaticMarkup(
-            <ContributionsEpic variant={variant} tracking={tracking} localisation={localisation} />,
+            <ContributionsEpic
+                variant={variant}
+                tracking={tracking}
+                localisation={localisation}
+                numArticles={numArticles}
+            />,
         ),
     );
     return { html, css };

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -152,7 +152,7 @@ app.post(
 
         const { targeting, expectedTest, expectedVariant } = req.body;
         const tests = await fetchConfiguredEpicTestsCached();
-        const got = findVariant(tests, targeting, targeting.epicViewLog);
+        const got = findVariant(tests, targeting);
 
         const notBothFalsy = expectedTest || got;
         const notTheSame = got?.test.name !== expectedTest || got?.variant.name !== expectedVariant;


### PR DESCRIPTION
## What's in this PR?
The types, logic and tests needed to include the article viewing history in the variant selection process. Also adds placeholder replacement for number of articles viewed in the Epic copy.

## Motivation
To achieve parity with Frontend, we need to track articles viewed on the platform and include this log in the Epic payload, to then be used in the variant selection logic and template rendering functions.

## Notes
This effectively adds support for article history in variants and templates, although we're not yet serving Epic variants. Only using them in the variant comparison endpoint.