### PR TITLE
Dynamically Select Test and Variant

### DIFF
--- a/src/api/contributionsApi.testData.ts
+++ b/src/api/contributionsApi.testData.ts
@@ -34,7 +34,7 @@ export const configuredTests: EpicTests = {
                 maxViewsDays: 30,
                 minDaysBetweenViews: 0,
             },
-            userCohort: 'AllNonSupporters',
+            userCohort: 'Everyone',
             isLiveBlog: false,
             hasCountryName: false,
             variants: [

--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -35,23 +35,23 @@ export const defaultStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         ophanComponentId: text('ophanComponentId', testData.tracking.ophanComponentId),
         platformId: text('platformId', testData.tracking.platformId),
+        clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
+        campaignId: text('campaignId', testData.tracking.campaignId),
         abTestName: text('abTestName', testData.tracking.abTestName),
         abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
         referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
     };
 
-    // Epic localisation props
-    const epicLocalisation = {
-        countryCode: text('countryCode', testData.localisation.countryCode || 'GB'),
-    };
+    // Epic countryCode prop
+    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
 
     return (
         <StorybookWrapper>
             <ContributionsEpic
                 variant={variant}
                 tracking={epicTracking}
-                localisation={epicLocalisation}
+                countryCode={countryCode}
                 numArticles={numArticles}
             />
         </StorybookWrapper>
@@ -76,23 +76,23 @@ export const backgroundImageStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         ophanComponentId: text('ophanComponentId', testData.tracking.ophanComponentId),
         platformId: text('platformId', testData.tracking.platformId),
+        clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
+        campaignId: text('campaignId', testData.tracking.campaignId),
         abTestName: text('abTestName', testData.tracking.abTestName),
         abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
         referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
     };
 
-    // Epic localisation props
-    const epicLocalisation = {
-        countryCode: text('countryCode', testData.localisation.countryCode || 'GB'),
-    };
+    // Epic countryCode prop
+    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
 
     return (
         <StorybookWrapper>
             <ContributionsEpic
                 variant={variant}
                 tracking={epicTracking}
-                localisation={epicLocalisation}
+                countryCode={countryCode}
                 numArticles={numArticles}
             />
         </StorybookWrapper>
@@ -120,23 +120,22 @@ export const secondaryButtonStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         ophanComponentId: text('ophanComponentId', testData.tracking.ophanComponentId),
         platformId: text('platformId', testData.tracking.platformId),
+        clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
+        campaignId: text('campaignId', testData.tracking.campaignId),
         abTestName: text('abTestName', testData.tracking.abTestName),
         abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
         referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
     };
 
-    // Epic localisation props
-    const epicLocalisation = {
-        countryCode: text('countryCode', testData.localisation.countryCode || 'GB'),
-    };
+    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
 
     return (
         <StorybookWrapper>
             <ContributionsEpic
                 variant={variant}
                 tracking={epicTracking}
-                localisation={epicLocalisation}
+                countryCode={countryCode}
                 numArticles={numArticles}
             />
         </StorybookWrapper>

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -1,4 +1,9 @@
-import { EpicTracking, EpicLocalisation, EpicTargeting } from './ContributionsEpicTypes';
+import {
+    EpicTestTracking,
+    EpicPageTracking,
+    EpicTracking,
+    EpicTargeting,
+} from './ContributionsEpicTypes';
 
 const content = {
     heading: 'Since you’re here...',
@@ -19,47 +24,41 @@ const content = {
     },
 };
 
-const tracking: EpicTracking = {
+const pageTracking: EpicPageTracking = {
     ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
     ophanComponentId: 'ACQUISITIONS_EPIC',
     platformId: 'GUARDIAN_WEB',
-    campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
-    abTestName: 'remote_epic_test',
-    abTestVariant: 'api',
+    clientName: 'dcr',
     referrerUrl:
         'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
 };
 
-const localisation: EpicLocalisation = {
-    countryCode: 'GB',
+const testTracking: EpicTestTracking = {
+    campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
+    campaignId: 'remote_epic_test',
+    abTestName: 'remote_epic_test',
+    abTestVariant: 'api',
+};
+
+const tracking: EpicTracking = {
+    ...pageTracking,
+    ...testTracking,
 };
 
 const targeting: EpicTargeting = {
     contentType: 'Article',
-    sectionName: 'culture',
+    sectionName: 'environment',
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,
     tags: [
         {
-            id: 'culture/david-schwimmer',
+            id: 'environment/drought',
             type: 'Keyword',
         },
         {
-            id: 'tv-and-radio/friends',
+            id: 'environment/climate-change',
             type: 'Keyword',
-        },
-        {
-            id: 'tone/interview',
-            type: 'Tone',
-        },
-        {
-            id: 'publication/theguardian',
-            type: 'Publication',
-        },
-        {
-            id: 'profile/davidsmith',
-            type: 'Contributor',
         },
     ],
     showSupportMessaging: true,
@@ -70,8 +69,9 @@ const targeting: EpicTargeting = {
         { week: 18337, count: 10 },
         { week: 18330, count: 5 },
     ],
+    countryCode: 'GB',
 };
 
-const testData = { content, tracking, localisation, targeting };
+const testData = { content, tracking, testTracking, pageTracking, targeting };
 
 export default testData;

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -5,7 +5,7 @@ import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
 import { getTrackingUrl } from '../lib/tracking';
 import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
-import { EpicLocalisation, EpicTracking } from './ContributionsEpicTypes';
+import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../lib/variants';
 import { Button } from './Button';
 
@@ -114,7 +114,7 @@ const buttonMargins = css`
 export type Props = {
     variant: Variant;
     tracking: EpicTracking;
-    localisation: EpicLocalisation;
+    countryCode?: string;
     numArticles: number;
 };
 
@@ -175,11 +175,10 @@ const EpicBody: React.FC<BodyProps> = ({ variant, countryCode, numArticles }: Bo
 export const ContributionsEpic: React.FC<Props> = ({
     variant,
     tracking,
-    localisation,
+    countryCode,
     numArticles,
 }: Props) => {
     const { heading, backgroundImageUrl, secondaryCta } = variant;
-    const { countryCode } = localisation;
 
     // Get button URL with tracking params in query string
     const buttonBaseUrl = 'https://support.theguardian.com/uk/contribute';

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -1,16 +1,19 @@
-export type EpicLocalisation = {
-    countryCode?: string;
-};
-
-export type EpicTracking = {
+export type EpicPageTracking = {
     ophanPageId: string;
     ophanComponentId: string;
     platformId: string;
-    campaignCode: string;
+    referrerUrl: string;
+    clientName: string;
+};
+
+export type EpicTestTracking = {
     abTestName: string;
     abTestVariant: string;
-    referrerUrl: string;
+    campaignCode: string;
+    campaignId: string;
 };
+
+export type EpicTracking = EpicPageTracking & EpicTestTracking;
 
 export type Tag = {
     id: string;
@@ -61,7 +64,6 @@ export type EpicTargeting = {
 };
 
 export type EpicPayload = {
-    tracking: EpicTracking;
-    localisation: EpicLocalisation;
+    tracking: EpicPageTracking;
     targeting: EpicTargeting;
 };

--- a/src/lib/tracking.test.ts
+++ b/src/lib/tracking.test.ts
@@ -1,4 +1,6 @@
-import { getTrackingUrl } from './tracking';
+import { buildCampaignCode, getTrackingUrl } from './tracking';
+import { Test, Variant } from '../lib/variants';
+import { configuredTests } from '../api/contributionsApi.testData';
 
 describe('getTrackingUrl', () => {
     it('should return a correctly formatted URL', () => {
@@ -6,8 +8,10 @@ describe('getTrackingUrl', () => {
             ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
             ophanComponentId: 'ACQUISITIONS_EPIC',
             platformId: 'GUARDIAN_WEB',
+            clientName: 'dcr',
             campaignCode:
                 'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
             abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
             abTestVariant: 'v2_stay_quiet',
             referrerUrl:
@@ -21,5 +25,25 @@ describe('getTrackingUrl', () => {
         const got = getTrackingUrl(buttonBaseUrl, dummyMeta);
 
         expect(got).toEqual(want);
+    });
+});
+
+describe('buildCampaignCode', () => {
+    it('returns the correct campaign code for the test and variant', () => {
+        const test: Test = {
+            ...configuredTests.tests[0],
+            name: 'enviro_fossil_fuel_r2_Epic__no_article_count',
+        };
+
+        const variant: Variant = {
+            ...configuredTests.tests[0].variants[0],
+            name: 'Control',
+        };
+
+        const campaignCode = buildCampaignCode(test, variant);
+
+        expect(campaignCode).toEqual(
+            'gdnwb_copts_memco_enviro_fossil_fuel_r2_Epic__no_article_count_Control',
+        );
     });
 });

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,4 +1,5 @@
 import { EpicTracking } from '../components/ContributionsEpicTypes';
+import { Test, Variant } from '../lib/variants';
 
 type LinkParams = {
     REFPVID: string;
@@ -32,3 +33,8 @@ export const getTrackingUrl = (baseUrl: string, params: EpicTracking): string =>
 
     return `${baseUrl}?${queryString.join('&')}`;
 };
+
+const campaignPrefix = 'gdnwb_copts_memco';
+
+export const buildCampaignCode = (test: Test, variant: Variant): string =>
+    `${campaignPrefix}_${test.name}_${variant.name}`;

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -1,5 +1,5 @@
 import {
-    findVariant,
+    findTestAndVariant,
     getUserCohorts,
     Test,
     hasCountryCode,
@@ -138,7 +138,7 @@ describe('find variant', () => {
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
         };
 
-        const got = findVariant(tests, targeting);
+        const got = findTestAndVariant(tests, targeting);
 
         expect(got?.test.name).toBe('example-1');
         expect(got?.variant.name).toBe('control-example-1');
@@ -148,7 +148,7 @@ describe('find variant', () => {
         const test = { ...testDefault, excludedSections: ['news'] };
         const tests = { tests: [test] };
         const targeting = { ...targetingDefault, sectionName: 'news' };
-        const got = findVariant(tests, targeting);
+        const got = findTestAndVariant(tests, targeting);
 
         expect(got).toBe(undefined);
     });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -234,12 +234,15 @@ export const shouldNotRender: Filter = {
     test: (_, targeting) => !shouldNotRenderEpic(targeting),
 };
 
-interface Result {
+export interface Result {
     test: Test;
     variant: Variant;
 }
 
-export const findVariant = (data: EpicTests, targeting: EpicTargeting): Result | undefined => {
+export const findTestAndVariant = (
+    data: EpicTests,
+    targeting: EpicTargeting,
+): Result | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
 

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -13,36 +13,20 @@
                 "platformId": {
                     "type": "string"
                 },
-                "campaignCode": {
-                    "type": "string"
-                },
-                "abTestName": {
-                    "type": "string"
-                },
-                "abTestVariant": {
-                    "type": "string"
-                },
                 "referrerUrl": {
+                    "type": "string"
+                },
+                "clientName": {
                     "type": "string"
                 }
             },
             "required": [
-                "abTestName",
-                "abTestVariant",
-                "campaignCode",
+                "clientName",
                 "ophanComponentId",
                 "ophanPageId",
                 "platformId",
                 "referrerUrl"
             ]
-        },
-        "localisation": {
-            "type": "object",
-            "properties": {
-                "countryCode": {
-                    "type": "string"
-                }
-            }
         },
         "targeting": {
             "type": "object",
@@ -133,7 +117,6 @@
         }
     },
     "required": [
-        "localisation",
         "targeting",
         "tracking"
     ],

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,3 +1,8 @@
+import request from 'supertest';
+import { app } from './server';
+import testData from './components/ContributionsEpic.testData';
+import { configuredTests } from './api/contributionsApi.testData';
+
 jest.mock('./api/contributionsApi', () => {
     return {
         fetchDefaultEpicContent: jest.fn().mockImplementation(() =>
@@ -7,22 +12,39 @@ jest.mock('./api/contributionsApi', () => {
                 highlighted: ['Highlight'],
             }),
         ),
+        fetchConfiguredEpicTests: jest
+            .fn()
+            .mockImplementation(() => Promise.resolve(configuredTests)),
     };
 });
 
-import request from 'supertest';
-import { app } from './server';
-import testData from './components/ContributionsEpic.testData';
+let oldEnableDynamicTestsConfig: string | undefined;
+
+beforeEach(() => {
+    oldEnableDynamicTestsConfig = process.env.ENABLE_DYNAMIC_TESTS;
+});
+
+afterEach(() => {
+    process.env.ENABLE_DYNAMIC_TESTS = oldEnableDynamicTestsConfig;
+});
+
+const enableDynamicTests = (): void => {
+    process.env.ENABLE_DYNAMIC_TESTS = 'true';
+};
+const disableDynamicTests = (): void => {
+    process.env.ENABLE_DYNAMIC_TESTS = 'false';
+};
 
 describe('POST /epic', () => {
     it('should return an epic when targeting is positive', async () => {
-        const { tracking, localisation, targeting } = testData;
+        enableDynamicTests();
+
+        const { pageTracking, targeting } = testData;
 
         const res = await request(app)
             .post('/epic')
             .send({
-                tracking,
-                localisation,
+                tracking: pageTracking,
                 targeting,
             });
 
@@ -30,6 +52,39 @@ describe('POST /epic', () => {
         expect(res.body).toHaveProperty('data');
         expect(res.body.data).toHaveProperty('html');
         expect(res.body.data).toHaveProperty('css');
+        expect(res.body.data).toHaveProperty('meta');
+        expect(res.body.data.meta).toEqual({
+            abTestName: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
+            abTestVariant: 'Control',
+            campaignCode:
+                'gdnwb_copts_memco_2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count_Control',
+            campaignId: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
+        });
+    });
+
+    it('should return the default epic when targeting is positive', async () => {
+        disableDynamicTests();
+
+        const { pageTracking, targeting } = testData;
+
+        const res = await request(app)
+            .post('/epic')
+            .send({
+                tracking: pageTracking,
+                targeting,
+            });
+
+        expect(res.status).toEqual(200);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data).toHaveProperty('html');
+        expect(res.body.data).toHaveProperty('css');
+        expect(res.body.data).toHaveProperty('meta');
+        expect(res.body.data.meta).toEqual({
+            abTestName: 'FrontendDotcomRenderingEpic',
+            abTestVariant: 'dcr',
+            campaignCode: 'gdnwb_copts_memco_frontend_dotcom_rendering_epic_dcr',
+            campaignId: 'frontend_dotcom_rendering_epic',
+        });
     });
 
     it('returns a 400 when an invalid payload is sent', async () => {


### PR DESCRIPTION
Start dynamically selecting a test and variant (or nothing depending on the targeting logic) instead of always returning the default epic. At this stage to mostly force us to figure out any decisions we still need to make.

When an epic is returned, we now include the `abTestName`, `abVariantName`, `campaignCode` and `campaignId` in the payload (under a `meta` key) so the client can use these for tracking, e.g. sending to Ophan.

The behaviour is controlled by an environment variable `ENABLE_DYNAMIC_TESTS`. Unless this is set to `true` the old behaviour of serving the default epic will happen.

There are other elements which need to be in place to fully support this (e.g. rendering of different variant elements which we don't yet support).

## TODO

- [x] Currently the client passes through tracking params for the Epic CTA in the `tracking` property of the request payload. I think some of these fields now need to be removed from there and instead come from the selected test/variant. Certainly `abTestName` and `abTestVariant` and presumably campaign code too (do we construct this from the test and variant name?).

## Notes

For the default epic variant name, we now depend on guardian/dotcom-rendering#1307 and guardian/frontend#22454, so those should be merged first.