### PR TITLE
Ignore empty string in hasTags filter

### DIFF
--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -72,11 +72,13 @@ export const selectVariant = (test: Test, mvtId: number): Variant => {
 export const hasTags: Filter = {
     id: 'hasTags',
     test: (test, targeting) => {
-        if (test.tagIds.length < 1) {
+        const cleanedTags = test.tagIds.filter(tagId => tagId !== '');
+
+        if (cleanedTags.length < 1) {
             return true;
         }
 
-        const intersection = test.tagIds.filter(tagId =>
+        const intersection = cleanedTags.filter(tagId =>
             targeting.tags.map(tag => tag.id).includes(tagId),
         );
 


### PR DESCRIPTION
This is what Frontend does and it appears there are real cases that expect this behaviour, though it is arguably a bug. I.e. this is the relevant test config in the wild:

```
      "tagIds" : [
        ""
      ],
```

The relevant Frontend code is here:

https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L205

("any string".includes("") is always true in this case.)