### PR TITLE
Add sensitive targeting check

### DIFF
--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -65,6 +65,7 @@ const targeting: EpicTargeting = {
         { week: 18337, count: 10 },
         { week: 18330, count: 5 },
     ],
+    isSensitive: false,
 };
 
 const testData = { content, tracking, localisation, targeting };

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -38,7 +38,7 @@ export type EpicTargeting = {
     // TODO let's replace these with Design Type/a single property after migration
     isMinuteArticle: boolean;
     isPaidContent: boolean;
-    isSensitive: boolean;
+    isSensitive?: boolean; // TODO make required once clients have caught up
 
     tags: Tag[];
     mvtId?: number;

--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -38,6 +38,7 @@ export type EpicTargeting = {
     // TODO let's replace these with Design Type/a single property after migration
     isMinuteArticle: boolean;
     isPaidContent: boolean;
+    isSensitive: boolean;
 
     tags: Tag[];
     mvtId?: number;

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -54,6 +54,12 @@ describe('shouldNotRenderEpic', () => {
         expect(got).toBe(true);
     });
 
+    it('return true if page is sensitive', () => {
+        const data = { ...meta, isSensitive: true };
+        const got = shouldNotRenderEpic(data);
+        expect(got).toBe(true);
+    });
+
     it('returns false for valid data', () => {
         const data = {
             contentType: 'Article',
@@ -64,6 +70,7 @@ describe('shouldNotRenderEpic', () => {
             isRecurringContributor: false,
             tags: [],
             showSupportMessaging: true,
+            isSensitive: false,
         };
         const got = shouldNotRenderEpic(data);
         expect(got).toBe(false);

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -73,6 +73,7 @@ export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
         meta.isPaidContent ||
         !meta.showSupportMessaging ||
         meta.isRecurringContributor ||
-        isRecentOneOffContributor(lastOneOffContributionDate)
+        isRecentOneOffContributor(lastOneOffContributionDate) ||
+        meta.isSensitive
     );
 };

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -128,7 +128,6 @@
                 "isMinuteArticle",
                 "isPaidContent",
                 "isRecurringContributor",
-                "isSensitive",
                 "sectionName",
                 "shouldHideReaderRevenue",
                 "showSupportMessaging",

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -62,6 +62,9 @@
                 "isPaidContent": {
                     "type": "boolean"
                 },
+                "isSensitive": {
+                    "type": "boolean"
+                },
                 "tags": {
                     "type": "array",
                     "items": {
@@ -125,6 +128,7 @@
                 "isMinuteArticle",
                 "isPaidContent",
                 "isRecurringContributor",
+                "isSensitive",
                 "sectionName",
                 "shouldHideReaderRevenue",
                 "showSupportMessaging",


### PR DESCRIPTION
**EDIT: THIS IS NOW OKAY. ~~DO NOT MERGE UNTIL CLIENT LIB AND PLATFORMS UPDATED TO PASS IT.~~**

In Frontend, tests won't run on sensitive pages:

https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/experiments/ab-core.js#L27

(Contributions tests don't override this I think so we can ignore the `shouldShowForSensitive` logic.)

I suspect this accounts for many/all of the comparison failures we have where the expected variant is undefined. These are a lot of the remaining cases.