### PR TITLE
Adds styles for link tags

### DIFF
--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -53,13 +53,27 @@ const headingStyles = css`
     margin-bottom: ${space[3]}px;
 `;
 
+// Custom styles for <a> tags in the Epic content
+const linkStyles = css`
+    a {
+        color: ${palette.news.main};
+        text-decoration: none;
+    }
+
+    a:hover {
+        text-decoration: underline;
+    }
+`;
+
 const bodyStyles = css`
     margin: 0 auto ${space[2]}px;
     ${body.medium()};
+    ${linkStyles}
 `;
 
 const highlightWrapperStyles = css`
     ${body.medium({ fontWeight: 'bold' })}
+    ${linkStyles}
 `;
 
 const highlightStyles = css`


### PR DESCRIPTION
Adds styling for `<a>` tags in the Epic body (paragraphs & highlighted text). Matches Frontend styles.

Before:
![Screenshot 2020-03-27 at 12 52 16](https://user-images.githubusercontent.com/1692169/77757925-0438f380-702a-11ea-8eb9-f3b280ff3de2.png)

After:
![Screenshot 2020-03-27 at 12 51 55](https://user-images.githubusercontent.com/1692169/77757940-09963e00-702a-11ea-8d58-9f81ff2a6a31.png)
