### PR TITLE
Log frontend data sent to comparison endpoint

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -167,7 +167,7 @@ app.post(
             return;
         }
 
-        const { targeting, expectedTest, expectedVariant } = req.body;
+        const { targeting, expectedTest, expectedVariant, frontendLog } = req.body;
 
         // Ignore some manually defined tests in Frontend for now
         const ignores = [
@@ -192,7 +192,7 @@ app.post(
             console.log(
                 `comparison failed: got (${`${got?.test.name}:${got?.variant.name}`}, want (${expectedTest}:${expectedVariant}), for targeting data ${JSON.stringify(
                     targeting,
-                )})`,
+                )} and frontend log data: ${JSON.stringify(frontendLog)})`,
             );
         }
 


### PR DESCRIPTION
For context, see: https://github.com/guardian/frontend/pull/22452.