### PR TITLE
Adds userCohort variant filter

### DIFF
--- a/src/components/ContributionsEpicTypes.ts
+++ b/src/components/ContributionsEpicTypes.ts
@@ -17,6 +17,12 @@ export type Tag = {
     type: string;
 };
 
+export type UserCohort =
+    | 'AllExistingSupporters'
+    | 'AllNonSupporters'
+    | 'Everyone'
+    | 'PostAskPauseSingleContributors';
+
 interface View {
     date: number;
     testId: string;

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,10 +1,10 @@
 import { daysSince, isRecentOneOffContributor } from '../lib/dates';
 
 describe('daysSince', () => {
+    const now = new Date('2020-02-18T10:30:00');
     it('should count the days properly', () => {
-        const then = new Date('2020-02-14T10:30:00');
-        const now = new Date('2020-02-18T10:30:00');
-        expect(daysSince(then, now)).toBe(4);
+        const then = new Date('2020-02-14T13:30:00');
+        expect(daysSince(then, now)).toBe(3);
     });
 });
 

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,0 +1,28 @@
+import { daysSince, isRecentOneOffContributor } from '../lib/dates';
+
+describe('daysSince', () => {
+    it('should count the days properly', () => {
+        const then = new Date('2020-02-14T10:30:00');
+        const now = new Date('2020-02-18T10:30:00');
+        expect(daysSince(then, now)).toBe(4);
+    });
+});
+
+describe('isRecentOneOffContributor', () => {
+    const now = new Date('2020-02-12T10:24:00');
+
+    it('returns true for recent date', () => {
+        const got = isRecentOneOffContributor(new Date('2020-02-10T10:24:00'), now);
+        expect(got).toBe(true);
+    });
+
+    it('returns false for older date', () => {
+        const got = isRecentOneOffContributor(new Date('2019-02-10T10:24:00'), now);
+        expect(got).toBe(false);
+    });
+
+    it('returns false for someone that has never contributed', () => {
+        const got = isRecentOneOffContributor(undefined, now);
+        expect(got).toBe(false);
+    });
+});

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,18 @@
+const pauseDays = 90;
+
+export const daysSince = (then: Date, now: Date): number => {
+    const oneDayMs = 1000 * 60 * 60 * 24;
+    const diffMs = now.valueOf() - then.valueOf();
+    return Math.floor(diffMs / oneDayMs);
+};
+
+export const isRecentOneOffContributor = (
+    lastOneOffContributionDate?: Date,
+    now: Date = new Date(Date.now()), // to mock out Date.now in tests
+): boolean => {
+    if (!lastOneOffContributionDate) {
+        return false;
+    }
+
+    return daysSince(lastOneOffContributionDate, now) <= pauseDays;
+};

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -2,18 +2,6 @@ import { isRecentOneOffContributor, shouldNotRenderEpic, shouldThrottle } from '
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import testData from '../components/ContributionsEpic.testData';
 
-// Note, this is okay because JS is single-threaded, but will cause issues once
-// tests include async code so really it is not very robust.
-const withNowAs = <T>(now: Date, fn: () => T): T => {
-    const old = Date.now;
-    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    Date.now = () => now.valueOf(); // override
-    const got = fn();
-    Date.now = old;
-
-    return got;
-};
-
 describe('isRecentOneOffContributor', () => {
     const now = new Date('2020-02-12T10:24:00');
 
@@ -39,12 +27,6 @@ describe('shouldNotRenderEpic', () => {
     it('returns true for non-article', () => {
         const data = { ...meta, contentType: 'Liveblog' };
         const got = shouldNotRenderEpic(data);
-        expect(got).toBe(true);
-    });
-
-    it('returns true for recent contributor', () => {
-        const data = { ...meta, lastOneOffContributionDate: 1557480240000 };
-        const got = withNowAs(new Date('2019-06-11T10:24:00'), () => shouldNotRenderEpic(data));
         expect(got).toBe(true);
     });
 

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -1,25 +1,6 @@
-import { isRecentOneOffContributor, shouldNotRenderEpic, shouldThrottle } from './targeting';
+import { shouldNotRenderEpic, shouldThrottle } from './targeting';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import testData from '../components/ContributionsEpic.testData';
-
-describe('isRecentOneOffContributor', () => {
-    const now = new Date('2020-02-12T10:24:00');
-
-    it('returns true for recent date', () => {
-        const got = isRecentOneOffContributor(new Date('2020-02-10T10:24:00'), now);
-        expect(got).toBe(true);
-    });
-
-    it('returns false for older date', () => {
-        const got = isRecentOneOffContributor(new Date('2019-02-10T10:24:00'), now);
-        expect(got).toBe(false);
-    });
-
-    it('returns false for someone that has never contributed', () => {
-        const got = isRecentOneOffContributor(undefined, now);
-        expect(got).toBe(false);
-    });
-});
 
 describe('shouldNotRenderEpic', () => {
     const meta: EpicTargeting = testData.targeting;

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -1,27 +1,9 @@
 import { EpicTargeting, ViewLog } from '../components/ContributionsEpicTypes';
+import { daysSince } from '../lib/dates';
 
 const lowValueSections = ['football', 'money', 'education', 'games', 'teacher-network', 'careers'];
 
 const lowValueTags = ['guardian-masterclasses/guardian-masterclasses'];
-
-const pauseDays = 90;
-
-const daysSince = (then: Date, now: Date): number => {
-    const oneDayMs = 1000 * 60 * 60 * 24;
-    const diffMs = now.valueOf() - then.valueOf();
-    return Math.floor(diffMs / oneDayMs);
-};
-
-export const isRecentOneOffContributor = (
-    lastOneOffContributionDate?: Date,
-    now: Date = new Date(Date.now()), // to mock out Date.now in tests
-): boolean => {
-    if (!lastOneOffContributionDate) {
-        return false;
-    }
-
-    return daysSince(lastOneOffContributionDate, now) <= pauseDays;
-};
 
 export interface ThrottleConfig {
     maxViewsDays: number;

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -60,19 +60,12 @@ export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
     const isLowValueSection = lowValueSections.some(id => id === meta.sectionName);
     const isLowValueTag = lowValueTags.some(id => meta.tags.some(pageTag => pageTag.id === id));
 
-    const lastOneOffContributionDate = meta.lastOneOffContributionDate
-        ? new Date(meta.lastOneOffContributionDate)
-        : undefined;
-
     return (
         meta.shouldHideReaderRevenue ||
         isLowValueSection ||
         isLowValueTag ||
         meta.contentType !== 'Article' ||
         meta.isMinuteArticle ||
-        meta.isPaidContent ||
-        !meta.showSupportMessaging ||
-        meta.isRecurringContributor ||
-        isRecentOneOffContributor(lastOneOffContributionDate)
+        meta.isPaidContent
     );
 };

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -121,9 +121,9 @@ describe('variant filters', () => {
     });
 
     it('should filter by user cohort', () => {
-        const now = new Date('2020-03-30T18:00:00');
-        const lessThanThreeMonthsAgo = new Date('2020-03-28T10:30:00');
-        const moreThanThreeMonthsAgo = new Date('2019-12-12T10:30:00');
+        const now = new Date();
+        const twoMonthsAgo = new Date(now.setMonth(now.getMonth() - 2)).getTime();
+        const fourMonthsAgo = new Date(now.setMonth(now.getMonth() - 4)).getTime();
 
         // 'AllNonSupporters'
         // Returns true if user is not a contributor
@@ -143,7 +143,7 @@ describe('variant filters', () => {
         // Returns false if user is one-off contributor
         const targeting3: EpicTargeting = {
             ...targetingDefault,
-            lastOneOffContributionDate: lessThanThreeMonthsAgo.getTime(),
+            lastOneOffContributionDate: twoMonthsAgo,
         };
         const got3 = withNowAs(now, () => inCorrectCohort.test(testDefault, targeting3));
         expect(got3).toBe(false);
@@ -185,7 +185,7 @@ describe('variant filters', () => {
             ...targetingDefault,
             showSupportMessaging: true,
             isRecurringContributor: false,
-            lastOneOffContributionDate: moreThanThreeMonthsAgo.getTime(),
+            lastOneOffContributionDate: fourMonthsAgo,
         };
         const got6 = inCorrectCohort.test(test6, targeting6);
         expect(got6).toBe(true);
@@ -200,7 +200,7 @@ describe('variant filters', () => {
             ...targetingDefault,
             showSupportMessaging: false,
             isRecurringContributor: false,
-            lastOneOffContributionDate: moreThanThreeMonthsAgo.getTime(),
+            lastOneOffContributionDate: fourMonthsAgo,
         };
         const got7 = inCorrectCohort.test(test7, targeting7);
         expect(got7).toBe(false);

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -132,7 +132,7 @@ describe('variant filters', () => {
     });
 
     it('should filter by user cohort', () => {
-        const mockDate = new Date('2020-03-30T18:00:00');
+        const now = new Date('2020-03-30T18:00:00');
         const lessThanThreeMonthsAgo = new Date('2020-03-28T10:30:00');
         const moreThanThreeMonthsAgo = new Date('2019-12-12T10:30:00');
 
@@ -157,7 +157,7 @@ describe('variant filters', () => {
             lastOneOffContributionDate: lessThanThreeMonthsAgo.getTime(),
         };
 
-        const got3 = withNowAs(mockDate, () => inCorrectCohort.test(testDefault, targeting3));
+        const got3 = withNowAs(now, () => inCorrectCohort.test(testDefault, targeting3));
         expect(got3).toBe(false);
 
         // 'AllExistingSupporters'

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -156,7 +156,6 @@ describe('variant filters', () => {
             ...targetingDefault,
             lastOneOffContributionDate: lessThanThreeMonthsAgo.getTime(),
         };
-
         const got3 = withNowAs(now, () => inCorrectCohort.test(testDefault, targeting3));
         expect(got3).toBe(false);
 

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -78,13 +78,19 @@ const targetingDefault: EpicTargeting = {
 
 describe('getUserCohort', () => {
     it('should return "AllNonSupporters" correctly', () => {
-        const got1 = getUserCohort(targetingDefault);
+        const targeting1 = {
+            ...targetingDefault,
+            showSupportMessaging: true,
+            isRecurringContributor: false,
+            lastOneOffContributionDate: undefined,
+        };
+        const got1 = getUserCohort(targeting1);
         expect(got1).toBe('AllNonSupporters');
     });
 
     it('should return "AllExistingSupporters" correctly', () => {
-        const now = new Date();
-        const twoMonthsAgo = new Date(now.setMonth(now.getMonth() - 2)).getTime();
+        const now = new Date('2020-03-31T12:30:00');
+        const twoMonthsAgo = new Date(now).setMonth(now.getMonth() - 2);
 
         const targeting1: EpicTargeting = {
             ...targetingDefault,
@@ -104,21 +110,21 @@ describe('getUserCohort', () => {
             ...targetingDefault,
             lastOneOffContributionDate: twoMonthsAgo,
         };
-        const got3 = getUserCohort(targeting3);
+        const got3 = withNowAs(now, () => getUserCohort(targeting3));
         expect(got3).toBe('AllExistingSupporters');
     });
     it('should return "PostAskPauseSingleContributors" correctly', () => {
-        const now = new Date();
-        const fourMonthsAgo = new Date(now.setMonth(now.getMonth() - 4)).getTime();
+        const now = new Date('2020-03-31T12:30:00');
+        const fourMonthsAgo = new Date(now).setMonth(now.getMonth() - 4);
 
-        const targeting: EpicTargeting = {
+        const targeting1: EpicTargeting = {
             ...targetingDefault,
             showSupportMessaging: true,
             isRecurringContributor: false,
             lastOneOffContributionDate: fourMonthsAgo,
         };
-        const got = getUserCohort(targeting);
-        expect(got).toBe('PostAskPauseSingleContributors');
+        const got1 = withNowAs(now, () => getUserCohort(targeting1));
+        expect(got1).toBe('PostAskPauseSingleContributors');
     });
 });
 

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -12,6 +12,7 @@ import {
     withinArticleViewedSettings,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
+import { withNowAs } from '../utils/withNowAs';
 
 const testDefault: Test = {
     name: 'example-1',
@@ -72,18 +73,6 @@ const targetingDefault: EpicTargeting = {
     isRecurringContributor: false,
     lastOneOffContributionDate: undefined,
     mvtId: 2,
-};
-
-// Note, this is okay because JS is single-threaded, but will cause issues once
-// tests include async code so really it is not very robust.
-const withNowAs = <T>(now: Date, fn: () => T): T => {
-    const old = Date.now;
-    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    Date.now = () => now.valueOf(); // override
-    const got = fn();
-    Date.now = old;
-
-    return got;
 };
 
 describe('find variant', () => {

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -132,8 +132,9 @@ describe('variant filters', () => {
     });
 
     it('should filter by user cohort', () => {
-        const lessThanThreeMonthsAgo = new Date('2020-03-28T10:30:00').getTime();
-        const moreThanThreeMonthsAgo = new Date('2019-12-12T10:30:00').getTime();
+        const mockDate = new Date('2020-03-30T18:00:00');
+        const lessThanThreeMonthsAgo = new Date('2020-03-28T10:30:00');
+        const moreThanThreeMonthsAgo = new Date('2019-12-12T10:30:00');
 
         // 'AllNonSupporters'
         // Returns true if user is not a contributor
@@ -153,12 +154,10 @@ describe('variant filters', () => {
         // Returns false if user is one-off contributor
         const targeting3: EpicTargeting = {
             ...targetingDefault,
-            lastOneOffContributionDate: lessThanThreeMonthsAgo,
+            lastOneOffContributionDate: lessThanThreeMonthsAgo.getTime(),
         };
 
-        const got3 = withNowAs(new Date('2020-03-30T18:00:00'), () =>
-            inCorrectCohort.test(testDefault, targeting3),
-        );
+        const got3 = withNowAs(mockDate, () => inCorrectCohort.test(testDefault, targeting3));
         expect(got3).toBe(false);
 
         // 'AllExistingSupporters'
@@ -198,7 +197,7 @@ describe('variant filters', () => {
             ...targetingDefault,
             showSupportMessaging: true,
             isRecurringContributor: false,
-            lastOneOffContributionDate: moreThanThreeMonthsAgo,
+            lastOneOffContributionDate: moreThanThreeMonthsAgo.getTime(),
         };
         const got6 = inCorrectCohort.test(test6, targeting6);
         expect(got6).toBe(true);
@@ -213,7 +212,7 @@ describe('variant filters', () => {
             ...targetingDefault,
             showSupportMessaging: false,
             isRecurringContributor: false,
-            lastOneOffContributionDate: moreThanThreeMonthsAgo,
+            lastOneOffContributionDate: moreThanThreeMonthsAgo.getTime(),
         };
         const got7 = inCorrectCohort.test(test7, targeting7);
         expect(got7).toBe(false);

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -92,12 +92,12 @@ export const getUserCohort = (targeting: EpicTargeting): UserCohort => {
     // User is a past-contributor if she doesn't have an active subscription
     // or recurring donation, but has made a one-off donation longer than 3
     // months ago.
-    const isPostAskPauseOneOffContributor =
+    const isPastContributor =
         !isSupporter &&
         lastOneOffContributionDate &&
         !isRecentOneOffContributor(lastOneOffContributionDate);
 
-    if (isPostAskPauseOneOffContributor) {
+    if (isPastContributor) {
         return 'PostAskPauseSingleContributors';
     } else if (isSupporter) {
         return 'AllExistingSupporters';

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -2,7 +2,7 @@ import { EpicTargeting, ViewLog, WeeklyArticleHistory } from '../components/Cont
 import { shouldThrottle, shouldNotRenderEpic } from '../lib/targeting';
 import { getArticleViewCountForWeeks } from '../lib/history';
 import { getCountryName, countryCodeToCountryGroupId } from '../lib/geolocation';
-import { isRecentOneOffContributor } from './targeting';
+import { isRecentOneOffContributor } from '../lib/dates';
 
 interface ArticlesViewedSettings {
     minViews: number;

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -101,11 +101,9 @@ export const getUserCohort = (targeting: EpicTargeting): UserCohort => {
         return 'PostAskPauseSingleContributors';
     } else if (isSupporter) {
         return 'AllExistingSupporters';
-    } else if (!isSupporter) {
-        return 'AllNonSupporters';
-    } else {
-        return 'Everyone';
     }
+
+    return 'AllNonSupporters';
 };
 
 export const hasSectionOrTags: Filter = {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -181,9 +181,8 @@ app.post(
             return;
         }
 
-        const shouldNotRender = shouldNotRenderEpic(targeting);
         const tests = await fetchConfiguredEpicTestsCached();
-        const got = shouldNotRender ? undefined : findVariant(tests, targeting);
+        const got = findVariant(tests, targeting);
 
         const notBothFalsy = expectedTest || got;
         const notTheSame = got?.test.name !== expectedTest || got?.variant.name !== expectedVariant;

--- a/src/utils/withNowAs.ts
+++ b/src/utils/withNowAs.ts
@@ -1,0 +1,11 @@
+// Note, this is okay because JS is single-threaded, but will cause issues once
+// tests include async code so really it is not very robust.
+export const withNowAs = <T>(now: Date, fn: () => T): T => {
+    const old = Date.now;
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    Date.now = () => now.valueOf(); // override
+    const got = fn();
+    Date.now = old;
+
+    return got;
+};


### PR DESCRIPTION
## What?
This moves the 'contributor status'  checks away from the targeting logic and into the variants logic, where they can be compared against the `userCohort` property in the test config.

This fundamentally drops the principle that Epics can only be served to non-contributors. They can effectively be served to either contributors, non-contributors or past-contributors, depending on the cohort set in the test: `AllNonSupporters`, `AllExistingSupporters`, `PostAskPauseSingleContributors` and `Everyone`. The user's cohort is determined by checking all 3 relevant targeting props: `showSupportMessaging`, `isRecurringContributor` and `lastOneOffContributionDate`.

## Why?
Because sometimes we want to thank our contributors by showing them an Epic with a nice message.