### PR TITLE
Ensure comparison error log is string, not JSON

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -189,11 +189,12 @@ app.post(
 
         if (notBothFalsy && notTheSame) {
             console.log(
-                JSON.stringify({
-                    status: 'comparison failed',
-                    targeting,
-                    frontendLog,
-                }),
+                'comparison failed with data: ' +
+                    JSON.stringify({
+                        status: 'comparison failed',
+                        targeting,
+                        frontendLog,
+                    }),
             );
         }
 


### PR DESCRIPTION
The suspicion is that our logging service detects and interprets pure JSON differently.

(This is speculative and will revert if doesn't work.)