### PR TITLE
Re-add got/want key info for comparison logging

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -192,6 +192,8 @@ app.post(
                 'comparison failed with data: ' +
                     JSON.stringify({
                         status: 'comparison failed',
+                        got: `${got?.test.name}:${got?.variant.name}`,
+                        want: `${expectedTest}:${expectedVariant}`,
                         targeting,
                         frontendLog,
                     }),


### PR DESCRIPTION
Originally dropped in https://github.com/guardian/contributions-service/pull/88.