### PR TITLE
Attempt user cohort filter fix (closer to frontend)

### DIFF
--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,4 +1,8 @@
-import { daysSince, isRecentOneOffContributor } from '../lib/dates';
+import {
+    daysSince,
+    isRecentOneOffContributor,
+    isPostAskPauseOneOffContributor,
+} from '../lib/dates';
 
 describe('daysSince', () => {
     const now = new Date('2020-02-18T10:30:00');
@@ -23,6 +27,25 @@ describe('isRecentOneOffContributor', () => {
 
     it('returns false for someone that has never contributed', () => {
         const got = isRecentOneOffContributor(undefined, now);
+        expect(got).toBe(false);
+    });
+});
+
+describe('isPostAskPauseOneOffContributor', () => {
+    const now = new Date('2020-02-12T10:24:00');
+
+    it('returns false for recent date', () => {
+        const got = isPostAskPauseOneOffContributor(new Date('2020-02-10T10:24:00'), now);
+        expect(got).toBe(false);
+    });
+
+    it('returns true for older date', () => {
+        const got = isPostAskPauseOneOffContributor(new Date('2019-02-10T10:24:00'), now);
+        expect(got).toBe(true);
+    });
+
+    it('returns false for someone that has never contributed', () => {
+        const got = isPostAskPauseOneOffContributor(undefined, now);
         expect(got).toBe(false);
     });
 });

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -16,3 +16,14 @@ export const isRecentOneOffContributor = (
 
     return daysSince(lastOneOffContributionDate, now) <= pauseDays;
 };
+
+export const isPostAskPauseOneOffContributor = (
+    lastOneOffContributionDate?: Date,
+    now: Date = new Date(Date.now()), // to mock out Date.now in tests
+): boolean => {
+    if (!lastOneOffContributionDate) {
+        return false;
+    }
+
+    return daysSince(lastOneOffContributionDate, now) > pauseDays;
+};


### PR DESCRIPTION
Modelled off the Frontend behaviour found here:

https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L160

From what I can tell, the Frontend logic doesn't attempt to assign a single user cohort to a user, but rather applies certain boolean checks against the user for the given cohort of the test to see if there is a match.