### PR TITLE
Add maxViews default

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -455,9 +455,9 @@ describe('variant filters', () => {
     it('should filter by max views', () => {
         const viewLog = [
             { date: new Date('2019-06-11T10:24:00').valueOf(), testId: 'example-1' },
-            { date: new Date('2019-07-11T10:24:00').valueOf(), testId: 'B' },
-            { date: new Date('2019-07-15T10:24:00').valueOf(), testId: 'example-1' },
-            { date: new Date('2019-07-17T10:24:00').valueOf(), testId: 'example-1' },
+            { date: new Date('2019-07-19T10:24:00').valueOf(), testId: 'B' },
+            { date: new Date('2019-07-19T10:24:00').valueOf(), testId: 'example-1' },
+            { date: new Date('2019-07-21T10:24:00').valueOf(), testId: 'example-1' },
             { date: new Date('2019-08-11T10:24:00').valueOf(), testId: 'example-1' },
         ];
 
@@ -467,7 +467,7 @@ describe('variant filters', () => {
         const test1 = {
             ...testDefault,
             maxViews: {
-                maxViewsCount: 4,
+                maxViewsCount: 5,
                 maxViewsDays: 30,
                 minDaysBetweenViews: 0,
             },
@@ -491,6 +491,17 @@ describe('variant filters', () => {
         const got2 = filter.test(test2, targetingDefault);
 
         expect(got2).toBe(false);
+
+        // Should apply default max views if test doesn't specify
+        const test3 = {
+            ...testDefault,
+            maxViews: undefined,
+            alwaysAsk: false,
+        };
+
+        const got3 = filter.test(test3, targetingDefault);
+
+        expect(got3).toBe(false);
     });
 
     it('should ignore max views when alwaysAsk is true', () => {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -196,13 +196,19 @@ export const matchesCountryGroups: Filter = {
 export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => ({
     id: 'shouldThrottle',
     test: (test, _) => {
-        if (test.alwaysAsk || !test.maxViews) {
+        const defaultMaxViews = {
+            maxViewsCount: 4,
+            maxViewsDays: 30,
+            minDaysBetweenViews: 0,
+        };
+
+        if (test.alwaysAsk) {
             return true;
         }
 
         const testId = test.useLocalViewLog ? test.name : undefined;
 
-        return !shouldThrottle(log, test.maxViews, testId, now);
+        return !shouldThrottle(log, test.maxViews || defaultMaxViews, testId, now);
     },
 });
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -21,7 +21,7 @@ import cors from 'cors';
 import { Validator } from 'jsonschema';
 import * as fs from 'fs';
 import * as path from 'path';
-import { findTestAndVariant } from './lib/variants';
+import { Test, findTestAndVariant, withinMaxViews } from './lib/variants';
 import { getArticleViewCountForWeeks } from './lib/history';
 import { buildCampaignCode } from './lib/tracking';
 
@@ -79,7 +79,10 @@ const buildEpic = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
 ): Promise<Epic | null> => {
-    if (shouldNotRenderEpic(targeting)) {
+    if (
+        shouldNotRenderEpic(targeting) ||
+        !withinMaxViews(targeting.epicViewLog || []).test({} as Test, targeting) // Note {} as Test is really flaky but is just for while we run the default Epic
+    ) {
         logTargeting(`Renders Epic false for targeting: ${JSON.stringify(targeting)}`);
         return null;
     }


### PR DESCRIPTION
Add maxViews default when test doesn't set it.

Also, apply the max views check to the default epic as well. This should help reduce the discrepancy between impressions in the `FrontendDotcomRenderingEpicTest`test.

For Frontend reference, see:

https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L342