### PR TITLE
Adds hasNoTicker filter

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -12,6 +12,7 @@ import {
     isContentType,
     withinArticleViewedSettings,
     userInTest,
+    hasNoTicker,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -556,5 +557,33 @@ describe('variant filters', () => {
 
         const got2 = isContentType.test(test2, targeting2);
         expect(got2).toBe(false);
+    });
+
+    it('should filter by ticker feature', () => {
+        // Fail if there are tickers
+        const test1 = {
+            ...testDefault,
+            variants: [
+                {
+                    ...testDefault.variants[0],
+                    showTicker: true,
+                },
+            ],
+        };
+        const got1 = hasNoTicker.test(test1, targetingDefault);
+        expect(got1).toBe(false);
+
+        // Pass if there are no tickers
+        const test2 = {
+            ...testDefault,
+            variants: [
+                {
+                    ...testDefault.variants[0],
+                    showTicker: false,
+                },
+            ],
+        };
+        const got2 = hasNoTicker.test(test2, targetingDefault);
+        expect(got2).toBe(true);
     });
 });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -235,6 +235,16 @@ export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({
     test: (test, _): boolean => userCohorts.includes(test.userCohort),
 });
 
+// This is a temporary filter to exclude tests with tickers until we have
+// support for these
+export const hasNoTicker: Filter = {
+    id: 'hasNoTicker',
+    test: (test, _) => {
+        const hasTicker = test.variants.some(variant => variant.showTicker);
+        return !hasTicker;
+    },
+};
+
 export const shouldNotRender: Filter = {
     id: 'shouldNotRender',
     test: (_, targeting) => !shouldNotRenderEpic(targeting),
@@ -266,6 +276,7 @@ export const findTestAndVariant = (
         withinMaxViews(targeting.epicViewLog || []),
         withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
         isContentType,
+        hasNoTicker,
     ];
 
     const priorityOrdered = ([] as Test[]).concat(

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -235,8 +235,7 @@ export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({
     test: (test, _): boolean => userCohorts.includes(test.userCohort),
 });
 
-// This is a temporary filter to exclude tests with tickers until we have
-// support for these
+// Temporary filter to exclude tests with tickers until we support them
 export const hasNoTicker: Filter = {
     id: 'hasNoTicker',
     test: (test, _) => {
@@ -261,7 +260,6 @@ export const findTestAndVariant = (
 ): Result | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
-
     // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L378
     const filters: Filter[] = [
         shouldNotRender,


### PR DESCRIPTION
This fails any test with a ticker set on any of its variants. Unless most (or all?) other test config options, this one is a property of the variant, not the test. So when we run the filter, we need to iterate through the variants and fail the whole test if it has a ticker on one of the variants. This might not be ultimately what we want, but we agreed this is a safety net and a temporary check until we have support for tickers.