### PR TITLE
Revert tsconfig changes

### DIFF
--- a/src/components/ContributionsEpic.js.ts
+++ b/src/components/ContributionsEpic.js.ts
@@ -3,7 +3,7 @@
 export const componentJs = function initAutomatJs(epicRoot: HTMLElement): void {
     // Helper function to validate email needs to be included in this
     // function body
-    const isValidEmail = (email: string): boolean => {
+    const isValidEmail = function(email: string): boolean {
         const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(String(email).toLowerCase());
     };
@@ -19,7 +19,7 @@ export const componentJs = function initAutomatJs(epicRoot: HTMLElement): void {
             '[data-target="toggle"]',
         );
         if (epicReminderToggle) {
-            epicReminderToggle.addEventListener('keyup', (event: KeyboardEvent): void => {
+            epicReminderToggle.addEventListener('keyup', function(event: KeyboardEvent): void {
                 if (event.keyCode === 13) {
                     epicReminderToggle.click();
                 }
@@ -29,7 +29,7 @@ export const componentJs = function initAutomatJs(epicRoot: HTMLElement): void {
             '[data-target="form"]',
         );
         if (epicReminderForm) {
-            epicReminderForm.addEventListener('submit', (event: Event): void => {
+            epicReminderForm.addEventListener('submit', function(event: Event): void {
                 event.preventDefault();
                 const epicReminderInput = epicReminder.querySelector<HTMLInputElement>(
                     '[data-target="input"]',
@@ -57,26 +57,30 @@ export const componentJs = function initAutomatJs(epicRoot: HTMLElement): void {
                         },
                         body: JSON.stringify(formValues),
                     })
-                        .then(response => {
+                        .then(function(response) {
                             if (!response.ok) {
                                 throw Error(response.statusText);
                             }
                             return response;
                         })
-                        .then(response => response.json())
-                        .then(json => {
+                        .then(function(response) {
+                            return response.json();
+                        })
+                        .then(function(json) {
                             if (json !== 'OK') {
                                 throw Error('Server error');
                             }
                             // Update form state: success
                             epicReminder.classList.add('success');
                         })
-                        .catch(error => {
+                        .catch(function(error) {
                             console.log('Error creating reminder: ', error);
                             // Update form state: error
                             epicReminder.classList.add('error');
                         })
-                        .finally(() => epicReminder.classList.remove('submitting'));
+                        .finally(function() {
+                            epicReminder.classList.remove('submitting');
+                        });
                 }
             });
         }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -164,6 +164,11 @@ const buildDynamicEpic = async (
         ...testTracking,
     };
 
+    variant.showReminderFields = {
+        reminderDate: '2020-05-18T09:30:00',
+        reminderDateAsString: 'May',
+    };
+
     // Hardcoding the number of weeks to match common values used in the tests.
     // We know the copy refers to 'articles viewed in past 4 months' and this
     // will show a count for the past year, but this seems to mirror Frontend

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -164,11 +164,6 @@ const buildDynamicEpic = async (
         ...testTracking,
     };
 
-    variant.showReminderFields = {
-        reminderDate: '2020-05-18T09:30:00',
-        reminderDateAsString: 'May',
-    };
-
     // Hardcoding the number of weeks to match common values used in the tests.
     // We know the copy refers to 'articles viewed in past 4 months' and this
     // will show a count for the past year, but this seems to mirror Frontend

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2018",
         "module": "commonjs",
         "strict": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
This reverts the changes recently made to the `target` value in `tsconfig` back to the initial value of `es2018` instead of `es5`. Additionally, tweaks the Epic Reminders JS code to decrease the need for es5 transpilation.