### PR TITLE
Adds hasNoZeroArticleCount variants filter

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -13,6 +13,7 @@ import {
     withinArticleViewedSettings,
     userInTest,
     hasNoTicker,
+    hasNoZeroArticleCount,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -372,6 +373,8 @@ describe('variant filters', () => {
     });
 
     it('should filter by articles viewed settings', () => {
+        const now = new Date('2020-03-31T12:30:00');
+
         // Test 1 - below min articles viewed
         const history1 = [{ week: 18330, count: 2 }];
         const targeting1: EpicTargeting = {
@@ -379,7 +382,7 @@ describe('variant filters', () => {
             weeklyArticleHistory: history1,
         };
 
-        const filter1 = withinArticleViewedSettings(history1);
+        const filter1 = withinArticleViewedSettings(history1, now);
 
         const got1 = filter1.test(testDefault, targeting1);
         expect(got1).toBe(false);
@@ -391,7 +394,7 @@ describe('variant filters', () => {
             weeklyArticleHistory: history2,
         };
 
-        const filter2 = withinArticleViewedSettings(history2);
+        const filter2 = withinArticleViewedSettings(history2, now);
 
         const got2 = filter2.test(testDefault, targeting2);
         expect(got2).toBe(true);
@@ -411,7 +414,7 @@ describe('variant filters', () => {
             weeklyArticleHistory: history3,
         };
 
-        const filter3 = withinArticleViewedSettings(history3);
+        const filter3 = withinArticleViewedSettings(history3, now);
 
         const got3 = filter3.test(test3, targeting3);
         expect(got3).toBe(true);
@@ -431,7 +434,7 @@ describe('variant filters', () => {
             weeklyArticleHistory: history4,
         };
 
-        const filter4 = withinArticleViewedSettings(history4);
+        const filter4 = withinArticleViewedSettings(history4, now);
 
         const got4 = filter4.test(test4, targeting4);
         expect(got4).toBe(false);
@@ -447,7 +450,7 @@ describe('variant filters', () => {
             weeklyArticleHistory: history5,
         };
 
-        const filter5 = withinArticleViewedSettings(history5);
+        const filter5 = withinArticleViewedSettings(history5, now);
 
         const got5 = filter5.test(test5, targeting5);
         expect(got5).toBe(true);
@@ -585,5 +588,39 @@ describe('variant filters', () => {
         };
         const got2 = hasNoTicker.test(test2, targetingDefault);
         expect(got2).toBe(true);
+    });
+
+    it('should filter by unreplaced or invalid article count copy', () => {
+        const now = new Date('2010-03-31T12:30:00');
+
+        // Pass if no need for article history
+        const test1: Test = {
+            ...testDefault,
+            articlesViewedSettings: undefined,
+        };
+
+        const filter1 = hasNoZeroArticleCount(now);
+        const got1 = filter1.test(test1, targetingDefault);
+        expect(got1).toBe(true);
+
+        // Pass if replacement value is greater than 0
+        const history2 = [{ week: 18330, count: 1 }];
+        const targeting2: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: history2,
+        };
+        const filter2 = hasNoZeroArticleCount(now);
+        const got2 = filter2.test(testDefault, targeting2);
+        expect(got2).toBe(true);
+
+        // Fail if replacement value is 0
+        const history3 = [{ week: 18330, count: 0 }];
+        const targeting3: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: history3,
+        };
+        const filter3 = hasNoZeroArticleCount(now);
+        const got3 = filter3.test(testDefault, targeting3);
+        expect(got3).toBe(false);
     });
 });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -254,24 +254,15 @@ export const hasNoTicker: Filter = {
     },
 };
 
-// Edge case filter to exclude any test where the combination of targeting data and variants logic
-// would allow the test to pass, but the value used to replace the article count
-// in the Epic copy is "0" (zero) due to all article views having been
-// within the`periodInWeeks` defined in the test (used for targeting)
-// but before (i.e. older) than the hardcoded `52` weeks (used for template rendering).
-// Prevents an Epic from ever rendering with text "...you've read 0 articles...".
-// This is needed because we use different timeframes when finding a
-// test/variant and when replacing the Epic placeholder, so we should
-// have a specific check around the logic/values used for template rendering.
-// This is intentional and in parity with Frontend.
+// Prevent cases like "...you've read 0 articles...".
+// This could happen when the article history required by the test
+// is different than the date range used by the template itself.
 export const hasNoZeroArticleCount = (now: Date = new Date()): Filter => ({
     id: 'hasNoZeroArticleCount',
     test: (test, targeting): boolean => {
-        // Check if the test requires an article history
         const mustHaveHistory =
             test.articlesViewedSettings && test.articlesViewedSettings.periodInWeeks;
 
-        // Return early if no need to check article history
         if (!mustHaveHistory) {
             return true;
         }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -257,7 +257,7 @@ export const hasNoTicker: Filter = {
 // Prevent cases like "...you've read 0 articles...".
 // This could happen when the article history required by the test
 // is different than the date range used by the template itself.
-export const hasNoZeroArticleCount = (now: Date = new Date()): Filter => ({
+export const hasNoZeroArticleCount = (now: Date = new Date(), templateWeeks = 52): Filter => ({
     id: 'hasNoZeroArticleCount',
     test: (test, targeting): boolean => {
         const mustHaveHistory =
@@ -267,13 +267,9 @@ export const hasNoZeroArticleCount = (now: Date = new Date()): Filter => ({
             return true;
         }
 
-        // Count number of articles viewed in 52 weeks
-        // Whereas filter 'withinArticleViewedSettings' uses a dynamic number of
-        // weeks as set in the test, we use an static value of 52 (one year) to
-        // match the value we use in the Epic to replace the placeholder with.
         const numArticlesInWeeks = getArticleViewCountForWeeks(
             targeting.weeklyArticleHistory || [],
-            52,
+            templateWeeks,
             now,
         );
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -256,7 +256,9 @@ export const hasNoTicker: Filter = {
 
 // Edge case filter to exclude any test where the combination of targeting data and variants logic
 // would allow the test to pass, but the value used to replace the article count
-// in the Epic copy is "0" (zero).
+// in the Epic copy is "0" (zero) due to all article views having been
+// within the`periodInWeeks` defined in the test (used for targeting)
+// but before (i.e. older) than the hardcoded `52` weeks (used for template rendering).
 // Prevents an Epic from ever rendering with text "...you've read 0 articles...".
 // This is needed because we use different timeframes when finding a
 // test/variant and when replacing the Epic placeholder, so we should


### PR DESCRIPTION
## What does this PR change?
Adds a new variants filter called `hasNoZeroArticleCount`, intended to capture an edge case where the combination of user targeting data and variants logic might allow a test to pass (user has seen sufficient articles to view that Epic) but the value used to replace the article count in the Epic copy is `0` (zero) due to all article views having been within the `periodInWeeks` defined in the test (used for targeting) but before/older than the hardcoded `52` weeks (used for template rendering).

## Why do we need this?
Because we use different timeframes when finding a test/variant and when replacing the Epic placeholder, so we should have a specific check around the logic/values used for template rendering so we never serve an Epic with copy saying "...you've read 0 articles..."

## Context
The ultimate goal is to ensure we never serve an Epic if it has an unreplaced template variable. Frontend does this in real time by looking for patterns in strings but we do it as a filter for consistency with the rest of our logic. This seems to be the only edge case we weren't safeguarding against, even tho it's extremely unlikely to make any significant difference in the rate of failed comparisons.

https://trello.com/c/6BX49e9A/101-add-filter-to-prevent-unreplaced-template-variables-from-being-served