### PR TITLE
Support for AskFourEarning hardcoded test

### DIFF
--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -37,4 +37,4 @@ export const getTrackingUrl = (baseUrl: string, params: EpicTracking): string =>
 const campaignPrefix = 'gdnwb_copts_memco';
 
 export const buildCampaignCode = (test: Test, variant: Variant): string =>
-    `${campaignPrefix}_${test.name}_${variant.name}`;
+    `${campaignPrefix}_${test.campaignId || test.name}_${variant.name}`;

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -14,6 +14,7 @@ import {
     userInTest,
     hasNoTicker,
     hasNoZeroArticleCount,
+    isNotExpired,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -622,5 +623,37 @@ describe('variant filters', () => {
         const filter3 = hasNoZeroArticleCount(now);
         const got3 = filter3.test(testDefault, targeting3);
         expect(got3).toBe(false);
+    });
+
+    it('should filter by expiration date if set', () => {
+        const now = new Date('2020-01-18T12:30:00');
+
+        // Fail if expiration date yesterday
+        const test1 = {
+            ...testDefault,
+            expiry: '2020-01-17',
+        };
+
+        const filter1 = isNotExpired(now);
+        const got1 = filter1.test(test1, targetingDefault);
+        expect(got1).toBe(false);
+
+        // Pass if expiration date today
+        const test2 = {
+            ...testDefault,
+            expiry: '2020-01-18',
+        };
+        const filter2 = isNotExpired(now);
+        const got2 = filter2.test(test2, targetingDefault);
+        expect(got2).toBe(true);
+
+        // Pass if expiration date tomorrow
+        const test3 = {
+            ...testDefault,
+            expiry: '2020-01-19',
+        };
+        const filter3 = isNotExpired(now);
+        const got3 = filter3.test(test3, targetingDefault);
+        expect(got3).toBe(true);
     });
 });

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -134,7 +134,7 @@ describe('getUserCohort', () => {
 
 describe('find variant', () => {
     it('should find the correct variant for test and targeting data', () => {
-        const tests = { tests: [testDefault] };
+        const tests = [testDefault];
         const targeting: EpicTargeting = {
             ...targetingDefault,
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
@@ -148,7 +148,7 @@ describe('find variant', () => {
 
     it('should return undefined when no matching test variant', () => {
         const test = { ...testDefault, excludedSections: ['news'] };
-        const tests = { tests: [test] };
+        const tests = [test];
         const targeting = { ...targetingDefault, sectionName: 'news' };
         const got = findTestAndVariant(tests, targeting);
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -69,13 +69,7 @@ export interface Test {
     audienceOffset?: number;
 
     // These are specific to hardcoded tests
-    start?: string;
     expiry?: string;
-    author?: string;
-    description?: string;
-    successMeasure?: string;
-    audienceCriteria?: string;
-    idealOutcome?: string;
     campaignId?: string;
 }
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -287,10 +287,7 @@ export interface Result {
     variant: Variant;
 }
 
-export const findTestAndVariant = (
-    data: EpicTests,
-    targeting: EpicTargeting,
-): Result | undefined => {
+export const findTestAndVariant = (tests: Test[], targeting: EpicTargeting): Result | undefined => {
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
     // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L378
@@ -312,8 +309,8 @@ export const findTestAndVariant = (
     ];
 
     const priorityOrdered = ([] as Test[]).concat(
-        data.tests.filter(test => test.highPriority),
-        data.tests.filter(test => !test.highPriority),
+        tests.filter(test => test.highPriority),
+        tests.filter(test => !test.highPriority),
     );
 
     const test = priorityOrdered.find(test =>

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -67,6 +67,19 @@ export interface Test {
     // they are always 0 and 1?
     audience?: number;
     audienceOffset?: number;
+
+    // These's a use case where we want the test to use a custom campaignId
+    // campaignId?: string;
+}
+
+export interface HardcodedTest extends Test {
+    start: string;
+    expiry: string;
+    author: string;
+    description: string;
+    successMeasure: string;
+    audienceCriteria: string;
+    idealOutcome: string;
 }
 
 export interface EpicTests {
@@ -283,7 +296,7 @@ export const shouldNotRender: Filter = {
 };
 
 export interface Result {
-    test: Test;
+    test: Test | HardcodedTest;
     variant: Variant;
 }
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -68,19 +68,15 @@ export interface Test {
     audience?: number;
     audienceOffset?: number;
 
-    // These's a use case where we want the test to use a custom campaignId
-    // campaignId?: string;
+    // These are only used by hardcoded tests
+    start?: string;
     expiry?: string;
-}
-
-export interface HardcodedTest extends Test {
-    start: string;
-    expiry: string;
-    author: string;
-    description: string;
-    successMeasure: string;
-    audienceCriteria: string;
-    idealOutcome: string;
+    author?: string;
+    description?: string;
+    successMeasure?: string;
+    audienceCriteria?: string;
+    idealOutcome?: string;
+    campaignId?: string;
 }
 
 export interface EpicTests {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -296,7 +296,7 @@ export const shouldNotRender: Filter = {
 };
 
 export interface Result {
-    test: Test | HardcodedTest;
+    test: Test;
     variant: Variant;
 }
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -68,7 +68,7 @@ export interface Test {
     audience?: number;
     audienceOffset?: number;
 
-    // These are only used by hardcoded tests
+    // These are specific to hardcoded tests
     start?: string;
     expiry?: string;
     author?: string;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -28,6 +28,7 @@ import {
     logging as loggingMiddleware,
 } from './middleware';
 import { ValidationError } from './errors/validationError';
+import { askFourEarningHardcodedTest } from './tests/askFourEarning';
 
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
@@ -75,6 +76,15 @@ const componentAsResponse = (componentWrapper: SlotComponent, meta: EpicTestTrac
         js,
         meta,
     };
+};
+
+const buildHardcodedTests = async (): Promise<Test[]> => {
+    const hardcodedTests: Test[] = [];
+
+    const askFourEarning = await askFourEarningHardcodedTest();
+    hardcodedTests.push(askFourEarning);
+
+    return hardcodedTests;
 };
 
 // Return the HTML and CSS from rendering the Epic to static markup
@@ -134,12 +144,13 @@ const buildDynamicEpic = async (
     targeting: EpicTargeting,
 ): Promise<Response | null> => {
     const configuredTests = await fetchConfiguredEpicTestsCached();
-    // const hardcodedTests = buildHardcodedTests();
-    const tests = [
-        ...configuredTests.tests,
-        // ...hardcodedTests,
-    ];
+    const hardcodedTests = await buildHardcodedTests();
+    // const tests = [...configuredTests.tests, ...hardcodedTests];
+    const tests = [...hardcodedTests];
     const result = findTestAndVariant(tests, targeting);
+
+    console.log('==== hardcodedTests: ');
+    console.log(hardcodedTests);
 
     if (!result) {
         logTargeting(`Renders Epic false for targeting: ${JSON.stringify(targeting)}`);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -142,11 +142,7 @@ const buildDynamicEpic = async (
     const configuredTests = await fetchConfiguredEpicTestsCached();
     const hardcodedTests = await buildHardcodedTests();
     const tests = [...configuredTests.tests, ...hardcodedTests];
-    // const tests = [...hardcodedTests];
     const result = findTestAndVariant(tests, targeting);
-
-    // console.log('==== hardcodedTests: ');
-    // console.log(hardcodedTests);
 
     if (!result) {
         logTargeting(`Renders Epic false for targeting: ${JSON.stringify(targeting)}`);
@@ -159,7 +155,7 @@ const buildDynamicEpic = async (
         abTestName: test.name,
         abTestVariant: variant.name,
         campaignCode: buildCampaignCode(test, variant),
-        campaignId: test.name,
+        campaignId: test.campaignId || test.name,
     };
 
     const tracking: EpicTracking = {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -28,7 +28,7 @@ import {
     logging as loggingMiddleware,
 } from './middleware';
 import { ValidationError } from './errors/validationError';
-import { askFourEarningHardcodedTest } from './tests/askFourEarning';
+import { getAllHardcodedTests } from './tests';
 
 const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
@@ -76,11 +76,6 @@ const componentAsResponse = (componentWrapper: SlotComponent, meta: EpicTestTrac
         js,
         meta,
     };
-};
-
-const buildHardcodedTests = async (): Promise<Test[]> => {
-    const askFourEarning = await askFourEarningHardcodedTest();
-    return [askFourEarning];
 };
 
 // Return the HTML and CSS from rendering the Epic to static markup
@@ -140,7 +135,7 @@ const buildDynamicEpic = async (
     targeting: EpicTargeting,
 ): Promise<Response | null> => {
     const configuredTests = await fetchConfiguredEpicTestsCached();
-    const hardcodedTests = await buildHardcodedTests();
+    const hardcodedTests = await getAllHardcodedTests();
     const tests = [...configuredTests.tests, ...hardcodedTests];
     const result = findTestAndVariant(tests, targeting);
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -133,7 +133,12 @@ const buildDynamicEpic = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
 ): Promise<Response | null> => {
-    const tests = await fetchConfiguredEpicTestsCached();
+    const configuredTests = await fetchConfiguredEpicTestsCached();
+    // const hardcodedTests = buildHardcodedTests();
+    const tests = [
+        ...configuredTests.tests,
+        // ...hardcodedTests,
+    ];
     const result = findTestAndVariant(tests, targeting);
 
     if (!result) {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -79,12 +79,8 @@ const componentAsResponse = (componentWrapper: SlotComponent, meta: EpicTestTrac
 };
 
 const buildHardcodedTests = async (): Promise<Test[]> => {
-    const hardcodedTests: Test[] = [];
-
     const askFourEarning = await askFourEarningHardcodedTest();
-    hardcodedTests.push(askFourEarning);
-
-    return hardcodedTests;
+    return [askFourEarning];
 };
 
 // Return the HTML and CSS from rendering the Epic to static markup

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -141,12 +141,12 @@ const buildDynamicEpic = async (
 ): Promise<Response | null> => {
     const configuredTests = await fetchConfiguredEpicTestsCached();
     const hardcodedTests = await buildHardcodedTests();
-    // const tests = [...configuredTests.tests, ...hardcodedTests];
-    const tests = [...hardcodedTests];
+    const tests = [...configuredTests.tests, ...hardcodedTests];
+    // const tests = [...hardcodedTests];
     const result = findTestAndVariant(tests, targeting);
 
-    console.log('==== hardcodedTests: ');
-    console.log(hardcodedTests);
+    // console.log('==== hardcodedTests: ');
+    // console.log(hardcodedTests);
 
     if (!result) {
         logTargeting(`Renders Epic false for targeting: ${JSON.stringify(targeting)}`);

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -20,7 +20,7 @@ export const askFourEarningHardcodedTest = async (): Promise<HardcodedTest> => {
         successMeasure: 'Conversion rate',
         idealOutcome: 'Acquires many Supporters',
         audienceCriteria: 'All',
-        campaignId: 'kr1_epic_ask_four_earning',
+        // campaignId: 'kr1_epic_ask_four_earning',
         //
         isOn: true,
         locations: [],

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -2,9 +2,10 @@ import { Test } from '../lib/variants';
 import { cacheAsync } from '../lib/cache';
 import { fetchDefaultEpicContent } from '../api/contributionsApi';
 
+const fiveMinutes = 60 * 5;
+const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
+
 export const askFourEarningHardcodedTest = async (): Promise<Test> => {
-    const fiveMinutes = 60 * 5;
-    const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
     const defaultEpicVariant = await fetchDefaultEpicContentCached();
 
     return {

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -1,0 +1,50 @@
+import { HardcodedTest } from '../lib/variants';
+import { cacheAsync } from '../lib/cache';
+import { fetchDefaultEpicContent } from '../api/contributionsApi';
+
+export const askFourEarningHardcodedTest = async (): Promise<HardcodedTest> => {
+    const fiveMinutes = 60 * 5;
+    const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
+    const defaultEpicVariant = await fetchDefaultEpicContentCached();
+
+    // TEST ONLY
+    defaultEpicVariant.heading = `${defaultEpicVariant.heading} (TEST)`;
+    return {
+        name: 'ContributionsEpicAskFourEarning',
+        // Hardcoded specific fields
+        start: '2017-01-24',
+        expiry: '2021-01-27',
+        author: 'Jonathan Rankin',
+        description:
+            'This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Acquires many Supporters',
+        audienceCriteria: 'All',
+        campaignId: 'kr1_epic_ask_four_earning',
+        //
+        isOn: true,
+        locations: [],
+        audience: 1,
+        tagIds: [],
+        sections: [],
+        excludedTagIds: [],
+        excludedSections: [],
+        alwaysAsk: false,
+        maxViews: {
+            maxViewsCount: 4,
+            maxViewsDays: 30,
+            minDaysBetweenViews: 0,
+        },
+        userCohort: 'AllNonSupporters',
+        isLiveBlog: false,
+        hasCountryName: false,
+        variants: [
+            {
+                ...defaultEpicVariant,
+                name: 'control',
+            },
+        ],
+        highPriority: false,
+        useLocalViewLog: false,
+    };
+};

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -1,3 +1,13 @@
+// Hardcoded test metadata - these are key/value pairs of the test in Frontend but we keep them as
+// comments as there's no business logic around them.
+// start: 2017-01-24
+// author: Jonathan Rankin
+// description: This places the epic on all articles for all users, with a limit
+// of 4 impressions in any given 30 days
+// successMeasure: Conversion rate
+// idealOutcome: Acquires many Supporters
+// audienceCriteria: All
+
 import { Test } from '../lib/variants';
 import { cacheAsync } from '../lib/cache';
 import { fetchDefaultEpicContent } from '../api/contributionsApi';
@@ -10,14 +20,7 @@ export const askFourEarningHardcodedTest = async (): Promise<Test> => {
 
     return {
         name: 'ContributionsEpicAskFourEarning',
-        start: '2017-01-24',
         expiry: '2021-01-27',
-        author: 'Jonathan Rankin',
-        description:
-            'This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days',
-        successMeasure: 'Conversion rate',
-        idealOutcome: 'Acquires many Supporters',
-        audienceCriteria: 'All',
         campaignId: 'kr1_epic_ask_four_earning',
         isOn: true,
         locations: [],

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -1,17 +1,14 @@
-import { HardcodedTest } from '../lib/variants';
+import { Test } from '../lib/variants';
 import { cacheAsync } from '../lib/cache';
 import { fetchDefaultEpicContent } from '../api/contributionsApi';
 
-export const askFourEarningHardcodedTest = async (): Promise<HardcodedTest> => {
+export const askFourEarningHardcodedTest = async (): Promise<Test> => {
     const fiveMinutes = 60 * 5;
     const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
     const defaultEpicVariant = await fetchDefaultEpicContentCached();
 
-    // TEST ONLY
-    defaultEpicVariant.heading = `${defaultEpicVariant.heading} (TEST)`;
     return {
         name: 'ContributionsEpicAskFourEarning',
-        // Hardcoded specific fields
         start: '2017-01-24',
         expiry: '2021-01-27',
         author: 'Jonathan Rankin',
@@ -20,8 +17,7 @@ export const askFourEarningHardcodedTest = async (): Promise<HardcodedTest> => {
         successMeasure: 'Conversion rate',
         idealOutcome: 'Acquires many Supporters',
         audienceCriteria: 'All',
-        // campaignId: 'kr1_epic_ask_four_earning',
-        //
+        campaignId: 'kr1_epic_ask_four_earning',
         isOn: true,
         locations: [],
         audience: 1,

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,0 +1,7 @@
+import { Test } from '../lib/variants';
+import { askFourEarningHardcodedTest } from '../tests/askFourEarning';
+
+export const getAllHardcodedTests = async (): Promise<Test[]> => {
+    const askFourEarning: Test = await askFourEarningHardcodedTest();
+    return [askFourEarning];
+};


### PR DESCRIPTION
Adds support for hardcoded tests by sharing the same interface as configured tests, with a few extra properties. Included addition of a new variants filter `isNotExpired` to ensure expired hardcoded tests don't run.

Co-authored with @tjmw 