### PR TITLE
Makes Epic primary CTA dynamic

### DIFF
--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
-import { getTrackingUrl } from '../lib/tracking';
+import { addTrackingParams } from '../lib/tracking';
 import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
@@ -185,11 +185,11 @@ export const ContributionsEpic: React.FC<Props> = ({
     countryCode,
     numArticles,
 }: Props) => {
-    const { heading, backgroundImageUrl, secondaryCta, showReminderFields } = variant;
+    const { heading, backgroundImageUrl, cta, secondaryCta, showReminderFields } = variant;
 
-    // Get button URL with tracking params in query string
-    const buttonBaseUrl = 'https://support.theguardian.com/uk/contribute';
-    const buttonTrackingUrl = getTrackingUrl(buttonBaseUrl, tracking);
+    const primaryCtaText = cta?.text || 'Support The Guardian';
+    const primaryCtaBaseUrl = cta?.baseUrl || 'https://support.theguardian.com/contribute';
+    const primaryCtaUrlWithParams = addTrackingParams(primaryCtaBaseUrl, tracking);
 
     return (
         <section className={wrapperStyles} data-target="contributions-epic">
@@ -216,8 +216,8 @@ export const ContributionsEpic: React.FC<Props> = ({
 
             <div className={buttonWrapperStyles} data-target="epic-buttons">
                 <div className={buttonMargins}>
-                    <Button onClickAction={buttonTrackingUrl} showArrow>
-                        Support The Guardian
+                    <Button onClickAction={primaryCtaUrlWithParams} showArrow>
+                        {primaryCtaText}
                     </Button>
                 </div>
                 {secondaryCta && secondaryCta.baseUrl && secondaryCta.text && (

--- a/src/lib/tracking.test.ts
+++ b/src/lib/tracking.test.ts
@@ -1,8 +1,8 @@
-import { buildCampaignCode, getTrackingUrl } from './tracking';
+import { buildCampaignCode, addTrackingParams } from './tracking';
 import { Test, Variant } from '../lib/variants';
 import { configuredTests } from '../api/contributionsApi.testData';
 
-describe('getTrackingUrl', () => {
+describe('addTrackingParams', () => {
     it('should return a correctly formatted URL', () => {
         const dummyMeta = {
             ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
@@ -22,7 +22,7 @@ describe('getTrackingUrl', () => {
         const want =
             'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%7D';
 
-        const got = getTrackingUrl(buttonBaseUrl, dummyMeta);
+        const got = addTrackingParams(buttonBaseUrl, dummyMeta);
 
         expect(got).toEqual(want);
     });

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -7,7 +7,7 @@ type LinkParams = {
     acquisitionData: string;
 };
 
-export const getTrackingUrl = (baseUrl: string, params: EpicTracking): string => {
+export const addTrackingParams = (baseUrl: string, params: EpicTracking): string => {
     const acquisitionData = encodeURIComponent(
         JSON.stringify({
             source: params.platformId,


### PR DESCRIPTION
This makes the primary CTA in the Epic use dynamic values if they've been set (true for configured tests), defaulting to the current values if not (true for hardcoded tests and default Epic).