### PR TITLE
Support internationalisation of Epic CTA links

### DIFF
--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -196,8 +196,6 @@ export const ContributionsEpic: React.FC<Props> = ({
     const primaryCtaBaseUrlWithRegionId = addRegionIdToSupportUrl(primaryCtaBaseUrl, countryCode);
     const primaryCtaUrlWithParams = addTrackingParams(primaryCtaBaseUrlWithRegionId, tracking);
 
-    console.log('primaryCtaBaseUrlWithRegionId: ', primaryCtaBaseUrlWithRegionId);
-
     return (
         <section className={wrapperStyles} data-target="contributions-epic">
             {backgroundImageUrl && (

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -4,7 +4,11 @@ import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
 import { addTrackingParams } from '../lib/tracking';
-import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
+import {
+    getCountryName,
+    getLocalCurrencySymbol,
+    addRegionIdToSupportUrl,
+} from '../lib/geolocation';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../lib/variants';
@@ -189,7 +193,10 @@ export const ContributionsEpic: React.FC<Props> = ({
 
     const primaryCtaText = cta?.text || 'Support The Guardian';
     const primaryCtaBaseUrl = cta?.baseUrl || 'https://support.theguardian.com/contribute';
-    const primaryCtaUrlWithParams = addTrackingParams(primaryCtaBaseUrl, tracking);
+    const primaryCtaBaseUrlWithRegionId = addRegionIdToSupportUrl(primaryCtaBaseUrl, countryCode);
+    const primaryCtaUrlWithParams = addTrackingParams(primaryCtaBaseUrlWithRegionId, tracking);
+
+    console.log('primaryCtaBaseUrlWithRegionId: ', primaryCtaBaseUrlWithRegionId);
 
     return (
         <section className={wrapperStyles} data-target="contributions-epic">

--- a/src/lib/geolocation.test.ts
+++ b/src/lib/geolocation.test.ts
@@ -1,4 +1,4 @@
-import { getCountryName, getLocalCurrencySymbol } from './geolocation';
+import { getCountryName, getLocalCurrencySymbol, addRegionIdToSupportUrl } from './geolocation';
 
 describe('getLocalCurrencySymbol', () => {
     const currencySymbolTests = [
@@ -27,5 +27,32 @@ describe('getCountryName', () => {
         it(`returns ${output}, given ${input}`, () => {
             expect(getCountryName(input)).toEqual(output);
         });
+    });
+});
+
+describe('addRegionIdToSupportUrl', () => {
+    const originalUrl = 'https://support.theguardian.com/contribute';
+    it('should modify the URL to include UK if country code is GB', () => {
+        const countryCode = 'GB';
+        const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/uk/contribute');
+    });
+
+    it('should modify the URL to include EU if country code is PT', () => {
+        const countryCode = 'PT';
+        const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/eu/contribute');
+    });
+
+    it('should modify the URL to include INT if country code is unknown', () => {
+        const countryCode = 'asdasd';
+        const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/int/contribute');
+    });
+
+    it('should not modify the URL if country code is missing', () => {
+        const countryCode = undefined;
+        const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/contribute');
     });
 });

--- a/src/lib/geolocation.test.ts
+++ b/src/lib/geolocation.test.ts
@@ -55,4 +55,11 @@ describe('addRegionIdToSupportUrl', () => {
         const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
         expect(modifiedUrl).toEqual('https://support.theguardian.com/contribute');
     });
+
+    it('should not modify the URL if it does not follow the expected pattern', () => {
+        const countryCode = 'GB';
+        const nonconformingUrl = 'https://www.theguardian.com/uk';
+        const modifiedUrl = addRegionIdToSupportUrl(nonconformingUrl, countryCode);
+        expect(modifiedUrl).toEqual(nonconformingUrl);
+    });
 });

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -7,12 +7,16 @@ type CountryGroupId =
     | 'NZDCountries'
     | 'Canada';
 
+// Used to internationalise 'Support the Guardian' links
+export type SupportRegionId = 'UK' | 'US' | 'AU' | 'EU' | 'INT' | 'NZ' | 'CA';
+
 type IsoCurrency = 'GBP' | 'USD' | 'AUD' | 'EUR' | 'NZD' | 'CAD';
 
 type CountryGroup = {
     name: string;
     currency: IsoCurrency;
     countries: string[];
+    supportRegionId: SupportRegionId;
 };
 
 type CountryGroups = Record<CountryGroupId, CountryGroup>;
@@ -22,16 +26,19 @@ const countryGroups: CountryGroups = {
         name: 'United Kingdom',
         currency: 'GBP',
         countries: ['GB', 'FK', 'GI', 'GG', 'IM', 'JE', 'SH'],
+        supportRegionId: 'UK',
     },
     UnitedStates: {
         name: 'United States',
         currency: 'USD',
         countries: ['US'],
+        supportRegionId: 'US',
     },
     AUDCountries: {
         name: 'Australia',
         currency: 'AUD',
         countries: ['AU', 'KI', 'NR', 'NF', 'TV'],
+        supportRegionId: 'AU',
     },
     EURCountries: {
         name: 'Europe',
@@ -93,6 +100,7 @@ const countryGroups: CountryGroups = {
             'VA',
             'AX',
         ],
+        supportRegionId: 'EU',
     },
     International: {
         name: 'International',
@@ -277,16 +285,19 @@ const countryGroups: CountryGroups = {
             'ZM',
             'ZW',
         ],
+        supportRegionId: 'INT',
     },
     NZDCountries: {
         name: 'New Zealand',
         currency: 'NZD',
         countries: ['NZ', 'CK'],
+        supportRegionId: 'NZ',
     },
     Canada: {
         name: 'Canada',
         currency: 'CAD',
         countries: ['CA'],
+        supportRegionId: 'CA',
     },
 };
 
@@ -393,4 +404,21 @@ export const getCountryName = (geolocation?: string): string | undefined => {
     }
 
     return undefined;
+};
+
+const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
+    countryGroups[countryCodeToCountryGroupId(countryCode)]?.supportRegionId;
+
+export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {
+    if (countryCode) {
+        const supportRegionId = countryCodeToSupportRegionId(countryCode);
+        if (supportRegionId) {
+            return originalUrl.replace(
+                /(support.theguardian.com)\/(contribute|subscribe)/,
+                (_, domain, path) => `${domain}/${supportRegionId.toLowerCase()}/${path}`,
+            );
+        }
+    }
+
+    return originalUrl;
 };


### PR DESCRIPTION
## What?
Adds a helper function to modify the Epic CTA link to include an internationalisation segment if we know the user's country code.

This modifies the original base URL (`https://support.theguardian.com/contribute`) to be, for example, `https://support.theguardian.com/eu/contribute` when the user is in a EU country.

## Why?
Because Frontend does the same and even though there's server-side redirection taking the user to a localised page, we'd rather preempt this and spare the user that unnecessary delay.

## Notes
This is more of an optimisation than a functional requirement, but it was mentioned to Tom in the Contributions team who agreed this adds value.