### PR TITLE
Make Epic CTA optional

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
+    roots: ['<rootDir>/src'],
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "@storybook/addons": "^5.3.8",
     "@storybook/preset-typescript": "^1.2.0",
     "@storybook/react": "^5.3.8",
+    "@testing-library/jest-dom": "^5.5.0",
+    "@testing-library/react": "^10.0.3",
     "@types/aws-serverless-express": "^3.3.2",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.1",

--- a/src/api/contributionsApi.test.ts
+++ b/src/api/contributionsApi.test.ts
@@ -46,6 +46,10 @@ describe('fetchDefaultEpic', () => {
             heading: 'Since you’re here...',
             paragraphs: ['First paragraph', 'Second paragraph'],
             highlightedText: 'Highlighted Text',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
         });
     });
 

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -22,6 +22,10 @@ export const fetchDefaultEpicContent = async (): Promise<Variant> => {
         paragraphs: [],
         showTicker: false,
         name: 'remote_epic_test',
+        cta: {
+            text: 'Support The Guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
     };
 
     const transformedData = control.reduce(

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -47,8 +47,15 @@ const tertiaryButtonOverrides = css`
     }
 `;
 
-export const Button: React.FC<Props> = (props: Props) => {
-    const { onClickAction, children, showArrow = false, priority = 'primary', isTertiary } = props;
+export const Button: React.FC<Props> = (allProps: Props) => {
+    const {
+        onClickAction,
+        children,
+        showArrow = false,
+        priority = 'primary',
+        isTertiary,
+        ...props
+    } = allProps;
 
     if (typeof onClickAction === 'string') {
         // LinkButton doesn't support 'tertiary' priority (unlike Button)

--- a/src/components/ContributionsEpic.stories.tsx
+++ b/src/components/ContributionsEpic.stories.tsx
@@ -28,6 +28,10 @@ export const defaultStory = (): ReactElement => {
         paragraphs: object('paragraphs', testData.content.paragraphs),
         highlightedText: text('highlightedText', testData.content.highlightedText),
         showTicker: false,
+        cta: {
+            text: text('primaryCta.text', testData.content.cta.text),
+            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+        },
     };
 
     // Epic metadata props
@@ -69,6 +73,10 @@ export const backgroundImageStory = (): ReactElement => {
         highlightedText: text('highlightedText', testData.content.highlightedText),
         showTicker: false,
         backgroundImageUrl: text('backgroundImageUrl', testData.content.backgroundImageUrl),
+        cta: {
+            text: text('primaryCta.text', testData.content.cta.text),
+            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+        },
     };
 
     // Epic metadata props
@@ -109,6 +117,10 @@ export const secondaryButtonStory = (): ReactElement => {
         paragraphs: object('paragraphs', testData.content.paragraphs),
         highlightedText: text('highlightedText', testData.content.highlightedText),
         showTicker: false,
+        cta: {
+            text: text('primaryCta.text', testData.content.cta.text),
+            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+        },
         secondaryCta: {
             text: text('secondaryCta.text', testData.content.secondaryCta.text),
             baseUrl: text('secondaryCta.baseUrl', testData.content.secondaryCta.baseUrl),
@@ -152,6 +164,10 @@ export const epicReminderStory = (): ReactElement => {
         paragraphs: object('paragraphs', testData.content.paragraphs),
         highlightedText: text('highlightedText', testData.content.highlightedText),
         showTicker: false,
+        cta: {
+            text: text('primaryCta.text', testData.content.cta.text),
+            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+        },
         showReminderFields: {
             reminderCTA: text('reminderCTA', testData.content.showReminderFields.reminderCTA),
             reminderDate: text('reminderDate', testData.content.showReminderFields.reminderDate),
@@ -190,3 +206,43 @@ export const epicReminderStory = (): ReactElement => {
 };
 
 epicReminderStory.story = { name: 'Epic with Reminder' };
+
+export const epicWithoutButtons = (): ReactElement => {
+    // Epic content props
+    const variant: Variant = {
+        name: 'Test Epic',
+        heading: text('heading', testData.content.heading),
+        paragraphs: object('paragraphs', testData.content.paragraphs),
+        highlightedText: text('highlightedText', testData.content.highlightedText),
+        showTicker: false,
+    };
+
+    // Epic metadata props
+    const epicTracking = {
+        ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
+        ophanComponentId: text('ophanComponentId', testData.tracking.ophanComponentId),
+        platformId: text('platformId', testData.tracking.platformId),
+        clientName: testData.tracking.clientName,
+        campaignCode: text('campaignCode', testData.tracking.campaignCode),
+        campaignId: text('campaignId', testData.tracking.campaignId),
+        abTestName: text('abTestName', testData.tracking.abTestName),
+        abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
+        referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
+    };
+
+    // Epic countryCode prop
+    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
+
+    return (
+        <StorybookWrapper>
+            <ContributionsEpic
+                variant={variant}
+                tracking={epicTracking}
+                countryCode={countryCode}
+                numArticles={numArticles}
+            />
+        </StorybookWrapper>
+    );
+};
+
+epicWithoutButtons.story = { name: 'Epic without buttons' };

--- a/src/components/ContributionsEpic.testData.ts
+++ b/src/components/ContributionsEpic.testData.ts
@@ -22,6 +22,10 @@ const content = {
         reminderDate: '2020-05-18T09:30:00',
         reminderDateAsString: 'May',
     },
+    cta: {
+        text: 'Support The Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
     secondaryCta: {
         text: 'Read our pledge',
         baseUrl:

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -3,18 +3,13 @@ import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
-import { addTrackingParams } from '../lib/tracking';
-import {
-    getCountryName,
-    getLocalCurrencySymbol,
-    addRegionIdToSupportUrl,
-} from '../lib/geolocation';
+import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../lib/variants';
 import { componentJs } from './ContributionsEpic.js';
-import { Button } from './Button';
 import { transform } from '@babel/standalone';
+import { EpicButtons } from './EpicButtons';
 
 const replacePlaceholders = (
     content: string,
@@ -88,24 +83,6 @@ const highlightStyles = css`
     background-color: ${palette.brandAlt[400]};
 `;
 
-const buttonWrapperStyles = css`
-    margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-
-    &.hidden {
-        display: none;
-    }
-`;
-
-const paymentImageStyles = css`
-    display: inline-block;
-    width: auto;
-    height: 25px;
-    margin: ${space[1]}px 0;
-`;
-
 const imageWrapperStyles = css`
     margin: 10px -4px 12px;
     height: 150px;
@@ -116,10 +93,6 @@ const imageStyles = css`
     height: 100%;
     width: 100%;
     object-fit: cover;
-`;
-
-const buttonMargins = css`
-    margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
 `;
 
 export type Props = {
@@ -189,12 +162,7 @@ export const ContributionsEpic: React.FC<Props> = ({
     countryCode,
     numArticles,
 }: Props) => {
-    const { heading, backgroundImageUrl, cta, secondaryCta, showReminderFields } = variant;
-
-    const primaryCtaText = cta?.text || 'Support The Guardian';
-    const primaryCtaBaseUrl = cta?.baseUrl || 'https://support.theguardian.com/contribute';
-    const primaryCtaBaseUrlWithRegionId = addRegionIdToSupportUrl(primaryCtaBaseUrl, countryCode);
-    const primaryCtaUrlWithParams = addTrackingParams(primaryCtaBaseUrlWithRegionId, tracking);
+    const { heading, backgroundImageUrl, showReminderFields } = variant;
 
     return (
         <section className={wrapperStyles} data-target="contributions-epic">
@@ -219,41 +187,7 @@ export const ContributionsEpic: React.FC<Props> = ({
 
             <EpicBody variant={variant} countryCode={countryCode} numArticles={numArticles} />
 
-            <div className={buttonWrapperStyles} data-target="epic-buttons">
-                <div className={buttonMargins}>
-                    <Button onClickAction={primaryCtaUrlWithParams} showArrow>
-                        {primaryCtaText}
-                    </Button>
-                </div>
-                {secondaryCta && secondaryCta.baseUrl && secondaryCta.text && (
-                    <div className={buttonMargins}>
-                        <Button onClickAction={secondaryCta.baseUrl} showArrow priority="secondary">
-                            {secondaryCta.text}
-                        </Button>
-                    </div>
-                )}
-
-                {showReminderFields && (
-                    <div className={buttonMargins}>
-                        <Button
-                            // We need to pass a function into 'onClickAction'
-                            // even though it won't be called when the button is
-                            // clicked post-injection on the client side.
-                            onClickAction={(): void => undefined}
-                            data-target="epic-open"
-                            isTertiary
-                        >
-                            {showReminderFields.reminderCTA}
-                        </Button>
-                    </div>
-                )}
-
-                <img
-                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                    className={paymentImageStyles}
-                />
-            </div>
+            <EpicButtons variant={variant} tracking={tracking} countryCode={countryCode} />
 
             {showReminderFields && (
                 <ContributionsEpicReminder

--- a/src/components/EpicButtons.test.tsx
+++ b/src/components/EpicButtons.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import testData from './ContributionsEpic.testData';
+
+import { EpicButtons } from './EpicButtons';
+
+describe('EpicButtons', () => {
+    it('Renders the primary button', () => {
+        const variant = {
+            ...testData.content,
+            name: 'Example',
+            showTicker: false,
+            cta: {
+                text: 'Button text!',
+                baseUrl: 'https://support.theguardian.com/support',
+            },
+        };
+        const tracking = testData.tracking;
+
+        render(<EpicButtons variant={variant} tracking={tracking} />);
+
+        expect(screen.getByText('Button text!')).toBeInTheDocument();
+    });
+
+    it('Renders nothing when no primary CTA', () => {
+        const variant = {
+            ...testData.content,
+            name: 'Example',
+            showTicker: false,
+            cta: undefined,
+        };
+        const tracking = testData.tracking;
+
+        const { queryByTestId } = render(<EpicButtons variant={variant} tracking={tracking} />);
+
+        expect(queryByTestId('epic-buttons')).toBeNull();
+    });
+});

--- a/src/components/EpicButtons.tsx
+++ b/src/components/EpicButtons.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { css } from 'emotion';
+import { space } from '@guardian/src-foundations';
+import { Button } from './Button';
+import { EpicTracking } from './ContributionsEpicTypes';
+import { Cta, Variant } from '../lib/variants';
+import { addTrackingParams } from '../lib/tracking';
+import { addRegionIdToSupportUrl } from '../lib/geolocation';
+
+const buttonWrapperStyles = css`
+    margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    &.hidden {
+        display: none;
+    }
+`;
+
+const paymentImageStyles = css`
+    display: inline-block;
+    width: auto;
+    height: 25px;
+    margin: ${space[1]}px 0;
+`;
+
+const buttonMargins = css`
+    margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
+`;
+
+const PrimaryCtaButton = ({
+    cta,
+    tracking,
+    countryCode,
+}: {
+    cta?: Cta;
+    tracking: EpicTracking;
+    countryCode?: string;
+}): JSX.Element | null => {
+    if (!cta) {
+        return null;
+    }
+
+    const buttonText = cta.text || 'Support The Guardian';
+    const baseUrl = cta.baseUrl || 'https://support.theguardian.com/contribute';
+    const urlWithRegion = addRegionIdToSupportUrl(baseUrl, countryCode);
+    const urlWithRegionAndTracking = addTrackingParams(urlWithRegion, tracking);
+
+    return (
+        <div className={buttonMargins}>
+            <Button onClickAction={urlWithRegionAndTracking} showArrow>
+                {buttonText}
+            </Button>
+        </div>
+    );
+};
+
+export const EpicButtons = ({
+    variant,
+    tracking,
+    countryCode,
+}: {
+    variant: Variant;
+    tracking: EpicTracking;
+    countryCode?: string;
+}): JSX.Element | null => {
+    const { cta, secondaryCta, showReminderFields } = variant;
+    if (!cta) {
+        return null;
+    }
+
+    return (
+        <div className={buttonWrapperStyles} data-target="epic-buttons" data-testid="epic=buttons">
+            <PrimaryCtaButton cta={cta} tracking={tracking} countryCode={countryCode} />
+
+            {secondaryCta && secondaryCta.baseUrl && secondaryCta.text && (
+                <div className={buttonMargins}>
+                    <Button onClickAction={secondaryCta.baseUrl} showArrow priority="secondary">
+                        {secondaryCta.text}
+                    </Button>
+                </div>
+            )}
+
+            {showReminderFields && (
+                <div className={buttonMargins}>
+                    <Button
+                        // We need to pass a function into 'onClickAction'
+                        // even though it won't be called when the button is
+                        // clicked post-injection on the client side.
+                        onClickAction={(): void => undefined}
+                        data-target="epic-open"
+                        isTertiary
+                    >
+                        {showReminderFields.reminderCTA}
+                    </Button>
+                </div>
+            )}
+
+            <img
+                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                className={paymentImageStyles}
+            />
+        </div>
+    );
+};

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -21,7 +21,7 @@ interface MaxViews {
     minDaysBetweenViews: number;
 }
 
-interface Cta {
+export interface Cta {
     text: string;
     baseUrl: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,12 +1031,27 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime-corejs3@^7.7.4":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz#26fe4aa77e9f1ecef9b776559bbb8e84d34284b7"
+  integrity sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/standalone@^7.9.5":
   version "7.9.5"
@@ -1406,6 +1421,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@mojotech/json-type-validation@^3.1.0":
   version "3.1.0"
@@ -1925,6 +1950,41 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/dom@^7.1.0":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.2.2.tgz#30ab09cca132fe49b2ca61ccd9ed785c5f0a6fc5"
+  integrity sha512-g+gT//COYh2FgRrlgcgdkifkjqSk7wQIS7F8jbrf6yoEsh85PJUJ/QtO0bJ9QU7pQPYQgKcgqNJsOs0dlyFYag==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__dom" "^7.0.0"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.4.2"
+    pretty-format "^25.1.0"
+
+"@testing-library/jest-dom@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.5.0.tgz#4707023e8f572021e8a84f65721303ff60828d88"
+  integrity sha512-7sWHrpxG4Yd8TmryI7Rtbx8Ff4mbs3ASye3oshQIuHvsCR+QHgr7rTR/PfeXvOmwUwR36wSTTAvrLKsPmr6VEQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.0.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^10.0.3":
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.3.tgz#7781adc75cce172f8cda28faa77be29c6270ab43"
+  integrity sha512-EVmd3ghDFBEjOSLnISUdi7OcLdP6tsqjmTprpMaBz5TreoM8jnxGKIPkLD579CE0LYGqK01iffQiy6wwW/RUig==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@testing-library/dom" "^7.1.0"
+    "@types/testing-library__react" "^10.0.0"
+
 "@types/aws-lambda@*":
   version "8.10.39"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.39.tgz#da83cf7a82695a8904e383d705829fecf96b7db2"
@@ -2068,6 +2128,14 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.1.tgz#9544cd438607955381c1bdbdb97767a249297db5"
+  integrity sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/jest@^24.0.25":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.0.tgz#78c6991cd1734cf0d390be24875e310bb0a9fb74"
@@ -2134,6 +2202,13 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-3.0.1.tgz#5433e2f503ea0e0831cbc6fd0c20f8157d93add0"
   integrity sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@*":
+  version "16.9.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.7.tgz#60844d48ce252d7b2dccf0c7bb937130e27c0cd2"
+  integrity sha512-GHTYhM8/OwUCf254WO5xqR/aqD3gC9kSTLpopWGpQLpnw23jk44RvMHsyUSEplvRJZdHxhJGMMLF0kCPYHPhQA==
   dependencies:
     "@types/react" "*"
 
@@ -2204,6 +2279,29 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/testing-library__dom@*", "@types/testing-library__dom@^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.0.2.tgz#2906f8a0dce58b0746c6ab606f786bd06fe6940e"
+  integrity sha512-8yu1gSwUEAwzg2OlPNbGq+ixhmSviGurBu1+ivxRKq1eRcwdjkmlwtPvr9VhuxTq2fNHBWN2po6Iem3Xt5A6rg==
+  dependencies:
+    pretty-format "^25.1.0"
+
+"@types/testing-library__jest-dom@^5.0.2":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.3.tgz#8efef348eeedc62e7de21acbe455a779936417c4"
+  integrity sha512-NdbKc6yseg6uq4UJFwimPws0iwsGugVbPoOTP2EH+PJMJKiZsoSg5F2H3XYweOyytftCOuIMuXifBUrF9CSvaQ==
+  dependencies:
+    "@types/jest" "*"
+
+"@types/testing-library__react@^10.0.0":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-10.0.1.tgz#92bb4a02394bf44428e35f1da2970ed77f803593"
+  integrity sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==
+  dependencies:
+    "@types/react-dom" "*"
+    "@types/testing-library__dom" "*"
+    pretty-format "^25.1.0"
+
 "@types/webpack-env@^1.15.0":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.0.tgz#bd9956d5044b1fb43e869a9ba9148862ff98d9fd"
@@ -2218,6 +2316,13 @@
   version "13.0.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.5.tgz#18121bfd39dc12f280cee58f92c5b21d32041908"
   integrity sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2700,6 +2805,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
+  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
+  dependencies:
+    "@babel/runtime" "^7.7.4"
+    "@babel/runtime-corejs3" "^7.7.4"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4165,6 +4278,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
 core-js-pure@^3.0.1:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
@@ -4402,6 +4520,21 @@ css-what@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4660,6 +4793,11 @@ diff-sequences@^24.9.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
+diff-sequences@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
+  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -4702,6 +4840,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.3.tgz#93ca9002eb222fd5a343b6e5e6b9cf5929411c4c"
+  integrity sha512-JZ8iPuEHDQzq6q0k7PKMGbrIdsgBB7TRrtVOUm4nSMCExlg5qQG4KXWTH2k90yggjM4tTumRGwTKJSldMzKyLA==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -7098,6 +7241,16 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -7143,6 +7296,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -7202,6 +7360,16 @@ jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -9172,6 +9340,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -9636,6 +9814,11 @@ react-inspector@^4.0.0:
     prop-types "^15.6.1"
     storybook-chromatic "^2.2.2"
 
+react-is@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -9867,6 +10050,14 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 refractor@^2.4.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.10.0.tgz#4cc7efc0028a87924a9b31d82d129dec831a287b"
@@ -9897,6 +10088,11 @@ regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"
@@ -10558,7 +10754,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==


### PR DESCRIPTION
https://trello.com/c/ZrFcJ2Ds/114-make-primary-cta-optional-in-the-epic-component

Previously if a primary CTA wasn't specified, we'd always fall back to a default. To mirror the behaviour on frontend we now:

* Omit the primary CTA if none is provided
* If a CTA _is_ provided but any of the fields (`text`, `baseUrl`) are falsy, then do fall back on defaults (in terms of `epic-tests.json` this is the difference between no `cta` data, and a `cta` with empty strings for some/all values, e.g. `cta: { text: "", baseUrl: ""}`)

Also includes an update to omit all buttons (secondary, reminder) and related furniture (container, payment methods image) if no CTA is present. This mirrors the functionality in [acquisitions-epic-buttons.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js) in frontend.

I've brought in [`react-testing-library`](https://github.com/testing-library/react-testing-library) in order to write some basic tests for the new `EpicButtons` component.