### PR TITLE
Don't render reminder button when secondary CTA present

### DIFF
--- a/src/components/EpicButtons.test.tsx
+++ b/src/components/EpicButtons.test.tsx
@@ -40,4 +40,54 @@ describe('EpicButtons', () => {
 
         expect(queryByTestId('epic-buttons')).toBeNull();
     });
+
+    it('Does not render the reminder button when secondary CTA present', () => {
+        const variant = {
+            ...testData.content,
+            name: 'Example',
+            showTicker: false,
+            cta: {
+                text: 'Button text!',
+                baseUrl: 'https://support.theguardian.com/support',
+            },
+            secondaryCta: {
+                text: 'Secondary button!',
+                baseUrl: 'https://support.theguardian.com/support',
+            },
+            showReminderFields: {
+                reminderCTA: 'Reminder button!',
+                reminderDateAsString: 'June',
+                reminderDate: '2020-06-01T09:30:00',
+            },
+        };
+        const tracking = testData.tracking;
+
+        const { queryByText } = render(<EpicButtons variant={variant} tracking={tracking} />);
+
+        expect(screen.getByText('Secondary button!')).toBeInTheDocument();
+        expect(queryByText('Reminder button!')).toBeNull();
+    });
+
+    it('Renders the reminder button when secondary CTA is not present', () => {
+        const variant = {
+            ...testData.content,
+            name: 'Example',
+            showTicker: false,
+            cta: {
+                text: 'Button text!',
+                baseUrl: 'https://support.theguardian.com/support',
+            },
+            secondaryCta: undefined,
+            showReminderFields: {
+                reminderCTA: 'Reminder button!',
+                reminderDateAsString: 'June',
+                reminderDate: '2020-06-01T09:30:00',
+            },
+        };
+        const tracking = testData.tracking;
+
+        render(<EpicButtons variant={variant} tracking={tracking} />);
+
+        expect(screen.getByText('Reminder button!')).toBeInTheDocument();
+    });
 });

--- a/src/components/EpicButtons.tsx
+++ b/src/components/EpicButtons.tsx
@@ -74,27 +74,27 @@ export const EpicButtons = ({
         <div className={buttonWrapperStyles} data-target="epic-buttons" data-testid="epic=buttons">
             <PrimaryCtaButton cta={cta} tracking={tracking} countryCode={countryCode} />
 
-            {secondaryCta && secondaryCta.baseUrl && secondaryCta.text && (
+            {secondaryCta && secondaryCta.baseUrl && secondaryCta.text ? (
                 <div className={buttonMargins}>
                     <Button onClickAction={secondaryCta.baseUrl} showArrow priority="secondary">
                         {secondaryCta.text}
                     </Button>
                 </div>
-            )}
-
-            {showReminderFields && (
-                <div className={buttonMargins}>
-                    <Button
-                        // We need to pass a function into 'onClickAction'
-                        // even though it won't be called when the button is
-                        // clicked post-injection on the client side.
-                        onClickAction={(): void => undefined}
-                        data-target="epic-open"
-                        isTertiary
-                    >
-                        {showReminderFields.reminderCTA}
-                    </Button>
-                </div>
+            ) : (
+                showReminderFields && (
+                    <div className={buttonMargins}>
+                        <Button
+                            // We need to pass a function into 'onClickAction'
+                            // even though it won't be called when the button is
+                            // clicked post-injection on the client side.
+                            onClickAction={(): void => undefined}
+                            data-target="epic-open"
+                            isTertiary
+                        >
+                            {showReminderFields.reminderCTA}
+                        </Button>
+                    </div>
+                )
             )}
 
             <img


### PR DESCRIPTION
Only render the reminder button if there's no secondary CTA. This reflects the current behaviour on frontend:

https://github.com/guardian/frontend/blob/23500ccc75b297db9e11e9027f65ac3d6dc9765b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js#L72