### PR TITLE
Add @emotion/core to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/standalone": "^7.9.5",
+    "@emotion/core": "^10.0.27",
     "@guardian/src-button": "^0.18.1",
     "@guardian/src-ed-lines": "^0.18.1",
     "@guardian/src-foundations": "^0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,18 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
+"@emotion/core@^10.0.27":
+  version "10.0.28"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
+  integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
 "@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"


### PR DESCRIPTION
Previously we were relying on @emotion/css being brought in indirectly via a storybook dependency. When that storybook dependency was removed in #116 it broke things. This makes the dependency explicit.