### PR TITLE
Temporarily disable 'articles viewed' epic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 dist/
 cloudformation.yaml
 cdk.out/
+.idea/

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -82,6 +82,23 @@ const targetingDefault: EpicTargeting = {
 
 describe('findTestAndVariant', () => {
     it('should find the correct variant for test and targeting data', () => {
+        const testWithoutArticlesViewedSettings = {
+            ...testDefault,
+            articlesViewedSettings: undefined,
+        };
+        const tests = [testWithoutArticlesViewedSettings];
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: [{ week: 18330, count: 45 }],
+        };
+
+        const got = findTestAndVariant(tests, targeting);
+
+        expect(got?.test.name).toBe('example-1');
+        expect(got?.variant.name).toBe('control-example-1');
+    });
+
+    it('should return undefined if test has articlesViewedSettings', () => {
         const tests = [testDefault];
         const targeting: EpicTargeting = {
             ...targetingDefault,
@@ -90,8 +107,6 @@ describe('findTestAndVariant', () => {
 
         const got = findTestAndVariant(tests, targeting);
 
-        // expect(got?.test.name).toBe('example-1');
-        // expect(got?.variant.name).toBe('control-example-1');
         expect(got).toBe(undefined);
     });
 

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -90,8 +90,9 @@ describe('findTestAndVariant', () => {
 
         const got = findTestAndVariant(tests, targeting);
 
-        expect(got?.test.name).toBe('example-1');
-        expect(got?.variant.name).toBe('control-example-1');
+        // expect(got?.test.name).toBe('example-1');
+        // expect(got?.variant.name).toBe('control-example-1');
+        expect(got).toBe(undefined);
     });
 
     it('should return undefined when no matching test variant', () => {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -223,6 +223,15 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
     },
 });
 
+// Temporarily disable all epics with articlesViewedSettings, while we test a new feature in frontend:
+// https://github.com/guardian/frontend/pull/22546
+export const noArticleViewedSettings: Filter = ({
+    id: 'noArticleViewedSettings',
+    test: (test, _): boolean => {
+        return !test.articlesViewedSettings
+    }
+});
+
 export const withinArticleViewedSettings = (
     history: WeeklyArticleHistory,
     now: Date = new Date(),
@@ -321,7 +330,8 @@ export const findTestAndVariant = (tests: Test[], targeting: EpicTargeting): Res
         hasCountryCode,
         matchesCountryGroups,
         withinMaxViews(targeting.epicViewLog || []),
-        withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
+        // withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
+        noArticleViewedSettings,
         isContentType,
         hasNoTicker,
         hasNoZeroArticleCount(),

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -225,12 +225,12 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
 
 // Temporarily disable all epics with articlesViewedSettings, while we test a new feature in frontend:
 // https://github.com/guardian/frontend/pull/22546
-export const noArticleViewedSettings: Filter = ({
+export const noArticleViewedSettings: Filter = {
     id: 'noArticleViewedSettings',
     test: (test, _): boolean => {
-        return !test.articlesViewedSettings
-    }
-});
+        return !test.articlesViewedSettings;
+    },
+};
 
 export const withinArticleViewedSettings = (
     history: WeeklyArticleHistory,


### PR DESCRIPTION
while we test this feature: https://github.com/guardian/frontend/pull/22546
we do not want to confuse things in the analysis