### PR TITLE
Remove default epic and tidyup controllers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,12 @@ module.exports = {
                 ignoreParameters: true,
             },
         ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                args: 'after-used',
+            },
+        ],
     },
     settings: {
         react: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,12 @@ module.exports = {
         // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
         // e.g. "@typescript-eslint/explicit-function-return-type": "off",
         curly: 2,
+        '@typescript-eslint/no-inferrable-types': [
+            'error',
+            {
+                ignoreParameters: true,
+            },
+        ],
     },
     settings: {
         react: {

--- a/src/components/ContributionsEpic.js.ts
+++ b/src/components/ContributionsEpic.js.ts
@@ -1,3 +1,5 @@
+import { transform } from '@babel/standalone';
+
 interface InitAutomatJsConfig {
     epicRoot: HTMLElement | ShadowRoot;
     onReminderOpen?: Function;
@@ -141,4 +143,21 @@ export const componentJs = function initAutomatJs({
             }
         }
     }
+};
+
+export const reminderJs = () => {
+    const contributionsReminderUrl =
+        process.env.NODE_ENV === 'production'
+            ? 'https://contribution-reminders.support.guardianapis.com/remind-me'
+            : 'https://contribution-reminders-code.support.guardianapis.com/remind-me';
+
+    const js = componentJs.toString();
+    const transpiled =
+        transform(js, {
+            presets: ['env'],
+        }).code || '';
+
+    return transpiled
+        .replace('"use strict";', '')
+        .replace(/%%CONTRIBUTIONS_REMINDER_URL%%/g, contributionsReminderUrl);
 };

--- a/src/components/ContributionsEpic.js.ts
+++ b/src/components/ContributionsEpic.js.ts
@@ -145,7 +145,7 @@ export const componentJs = function initAutomatJs({
     }
 };
 
-export const reminderJs = () => {
+export const reminderJs = (): string => {
     const contributionsReminderUrl =
         process.env.NODE_ENV === 'production'
             ? 'https://contribution-reminders.support.guardianapis.com/remind-me'

--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -7,8 +7,7 @@ import { getCountryName, getLocalCurrencySymbol } from '../lib/geolocation';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../lib/variants';
-import { componentJs } from './ContributionsEpic.js';
-import { transform } from '@babel/standalone';
+import { reminderJs } from './ContributionsEpic.js';
 import { EpicButtons } from './EpicButtons';
 
 const replacePlaceholders = (
@@ -200,30 +199,18 @@ export const ContributionsEpic: React.FC<Props> = ({
     );
 };
 
-export interface SlotComponent {
-    component: JSX.Element;
+export interface JsComponent {
+    el: JSX.Element;
     js: string;
 }
 
-export const contributionsEpicSlot = (props: Props): SlotComponent => {
+export const getEpic = (props: Props): JsComponent => {
     let js = '';
+    const el = <ContributionsEpic {...props} />;
+
     if (props.variant.showReminderFields) {
-        const contributionsReminderUrl =
-            process.env.NODE_ENV === 'production'
-                ? 'https://contribution-reminders.support.guardianapis.com/remind-me'
-                : 'https://contribution-reminders-code.support.guardianapis.com/remind-me';
-        const componentJsAsString = componentJs.toString();
-        const componentJsTranspiled = transform(componentJsAsString, {
-            presets: ['env'],
-        }).code;
-        if (componentJsTranspiled) {
-            js = componentJsTranspiled
-                .replace('"use strict";', '')
-                .replace(/%%CONTRIBUTIONS_REMINDER_URL%%/g, contributionsReminderUrl);
-        }
+        js = reminderJs();
     }
-    return {
-        component: <ContributionsEpic {...props} />,
-        js,
-    };
+
+    return { el, js };
 };

--- a/src/errors/validationError.ts
+++ b/src/errors/validationError.ts
@@ -1,3 +1,0 @@
-class ValidationError extends Error {}
-
-export { ValidationError };

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -11,7 +11,7 @@ export const cacheAsync = <T>(
     const myCache = new NodeCache();
     const key = 'res';
 
-    const retFn = async () => {
+    const retFn = async (): Promise<T> => {
         const got = myCache.get(key);
         if (got !== undefined) {
             return got as T;
@@ -22,7 +22,7 @@ export const cacheAsync = <T>(
         return res;
     };
 
-    const resetFn = () => myCache.del(key);
+    const resetFn = (): number => myCache.del(key);
 
     return [resetFn, retFn];
 };

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -10,7 +10,7 @@ export const getMondayFromDate = (date: Date): number => {
 
 export const getArticleViewCountForWeeks = (
     history: WeeklyArticleHistory = [],
-    weeks: number,
+    weeks: number = 52,
     rightNow: Date = new Date(),
 ): number => {
     const mondayThisWeek = getMondayFromDate(rightNow);

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,0 +1,5 @@
+export const logTargeting = (message: string): void => {
+    if (process.env.LOG_TARGETING === 'true') {
+        console.log(message);
+    }
+};

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,22 @@
+import { EpicPayload } from '../components/ContributionsEpicTypes';
+import { Validator } from 'jsonschema';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const validator = new Validator(); // reuse as expensive to initialise
+const schemaPath = path.join(__dirname, '../schemas', 'epicPayload.schema.json');
+const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+console.log('Loaded epic payload JSON schema');
+
+export class ValidationError extends Error {}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const validatePayload = (body: any): EpicPayload => {
+    const validation = validator.validate(body, epicPayloadSchema);
+
+    if (!validation.valid) {
+        throw new ValidationError(validation.toString());
+    }
+
+    return body as EpicPayload;
+};

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -51,7 +51,7 @@ export interface Test {
     locations: string[];
     tagIds: string[];
     sections: string[];
-    excludedTagIds: any[];
+    excludedTagIds: string[];
     excludedSections: string[];
     alwaysAsk: boolean;
     maxViews?: MaxViews;
@@ -159,7 +159,7 @@ export const excludeTags: Filter = {
 
 export const isOn: Filter = {
     id: 'isOn',
-    test: (test, _) => test.isOn,
+    test: (test): boolean => test.isOn,
 };
 
 export const isContentType: Filter = {
@@ -170,7 +170,7 @@ export const isContentType: Filter = {
 // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/experiments/ab-core.js#L39
 export const userInTest = (mvtId: number): Filter => ({
     id: 'userInTest',
-    test: (test, _) => {
+    test: (test): boolean => {
         // Calculate range of mvtIDs for variants and return first match
         const maxMVTId = 1000000;
         const lowest = maxMVTId * (test.audienceOffset || 0);
@@ -181,7 +181,7 @@ export const userInTest = (mvtId: number): Filter => ({
 
 export const hasCountryCode: Filter = {
     id: 'hasCountryGroups',
-    test: (test, targeting) =>
+    test: (test, targeting): boolean =>
         test.hasCountryName ? !!getCountryName(targeting.countryCode) : true,
 };
 
@@ -206,7 +206,7 @@ export const matchesCountryGroups: Filter = {
 
 export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => ({
     id: 'shouldThrottle',
-    test: (test, _) => {
+    test: (test): boolean => {
         const defaultMaxViews = {
             maxViewsCount: 4,
             maxViewsDays: 30,
@@ -228,7 +228,7 @@ export const withinArticleViewedSettings = (
     now: Date = new Date(),
 ): Filter => ({
     id: 'withinArticleViewedSettings',
-    test: (test, _): boolean => {
+    test: (test): boolean => {
         // Allow test to pass if no articles viewed settings have been set
         if (!test.articlesViewedSettings || !test.articlesViewedSettings.periodInWeeks) {
             return true;
@@ -246,13 +246,13 @@ export const withinArticleViewedSettings = (
 
 export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({
     id: 'inCorrectCohort',
-    test: (test, _): boolean => userCohorts.includes(test.userCohort),
+    test: (test): boolean => userCohorts.includes(test.userCohort),
 });
 
 // Temporary filter to exclude tests with tickers until we support them
 export const hasNoTicker: Filter = {
     id: 'hasNoTicker',
-    test: (test, _) => {
+    test: test => {
         const hasTicker = test.variants.some(variant => variant.showTicker);
         return !hasTicker;
     },
@@ -288,7 +288,7 @@ export const shouldNotRender: Filter = {
 
 export const isNotExpired = (now: Date = new Date()): Filter => ({
     id: 'isNotExpired',
-    test: (test, _): boolean => {
+    test: (test): boolean => {
         if (!test.expiry) {
             return true;
         }

--- a/src/middleware/errorHandling.ts
+++ b/src/middleware/errorHandling.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { ValidationError } from '../errors/validationError';
+import { ValidationError } from '../lib/validation';
 
 export const errorHandling = (
     error: Error,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -18,27 +18,8 @@ jest.mock('./api/contributionsApi', () => {
     };
 });
 
-let oldEnableDynamicTestsConfig: string | undefined;
-
-beforeEach(() => {
-    oldEnableDynamicTestsConfig = process.env.ENABLE_DYNAMIC_TESTS;
-});
-
-afterEach(() => {
-    process.env.ENABLE_DYNAMIC_TESTS = oldEnableDynamicTestsConfig;
-});
-
-const enableDynamicTests = (): void => {
-    process.env.ENABLE_DYNAMIC_TESTS = 'true';
-};
-const disableDynamicTests = (): void => {
-    process.env.ENABLE_DYNAMIC_TESTS = 'false';
-};
-
 describe('POST /epic', () => {
-    it('should return an epic when targeting is positive', async () => {
-        enableDynamicTests();
-
+    it('should return an epic', async () => {
         const { pageTracking, targeting } = testData;
 
         const res = await request(app)
@@ -59,31 +40,6 @@ describe('POST /epic', () => {
             campaignCode:
                 'gdnwb_copts_memco_2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count_Control',
             campaignId: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
-        });
-    });
-
-    it('should return the default epic when targeting is positive', async () => {
-        disableDynamicTests();
-
-        const { pageTracking, targeting } = testData;
-
-        const res = await request(app)
-            .post('/epic')
-            .send({
-                tracking: pageTracking,
-                targeting,
-            });
-
-        expect(res.status).toEqual(200);
-        expect(res.body).toHaveProperty('data');
-        expect(res.body.data).toHaveProperty('html');
-        expect(res.body.data).toHaveProperty('css');
-        expect(res.body.data).toHaveProperty('meta');
-        expect(res.body.data.meta).toEqual({
-            abTestName: 'FrontendDotcomRenderingEpic',
-            abTestVariant: 'dcr',
-            campaignCode: 'gdnwb_copts_memco_frontend_dotcom_rendering_epic_dcr',
-            campaignId: 'frontend_dotcom_rendering_epic',
         });
     });
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -4,7 +4,7 @@ import { Context } from 'aws-lambda';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
-import { fetchDefaultEpicContent, fetchConfiguredEpicTests } from './api/contributionsApi';
+import { fetchConfiguredEpicTests } from './api/contributionsApi';
 import { cacheAsync } from './lib/cache';
 import { JsComponent, getEpic } from './components/ContributionsEpic';
 import {
@@ -12,27 +12,18 @@ import {
     EpicTestTracking,
     EpicTracking,
     EpicTargeting,
-    EpicPayload,
 } from './components/ContributionsEpicTypes';
-import { shouldNotRenderEpic } from './lib/targeting';
 import testData from './components/ContributionsEpic.testData';
 import cors from 'cors';
-import { Validator } from 'jsonschema';
-import * as fs from 'fs';
-import * as path from 'path';
-import { Test, findTestAndVariant, withinMaxViews } from './lib/variants';
+import { validatePayload } from './lib/validation';
+import { findTestAndVariant } from './lib/variants';
 import { getArticleViewCountForWeeks } from './lib/history';
 import { buildCampaignCode } from './lib/tracking';
 import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
 } from './middleware';
-import { ValidationError } from './errors/validationError';
 import { getAllHardcodedTests } from './tests';
-
-const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
-const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-console.log('Loaded epic payload JSON schema');
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -55,8 +46,6 @@ interface Response {
     meta: EpicTestTracking;
 }
 
-const fiveMinutes = 60 * 5;
-const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
 const [, fetchConfiguredEpicTestsCached] = cacheAsync(fetchConfiguredEpicTests, 60);
 
 const logTargeting = (message: string): void => {
@@ -78,50 +67,6 @@ const componentAsResponse = (componentWrapper: JsComponent, meta: EpicTestTracki
 };
 
 const buildEpic = async (
-    pageTracking: EpicPageTracking,
-    targeting: EpicTargeting,
-): Promise<Response | null> => {
-    if (
-        shouldNotRenderEpic(targeting) ||
-        !withinMaxViews(targeting.epicViewLog || []).test({} as Test, targeting) // Note {} as Test is really flaky but is just for while we run the default Epic
-    ) {
-        logTargeting(`Renders Epic false for targeting: ${JSON.stringify(targeting)}`);
-        return null;
-    }
-
-    const variant = await fetchDefaultEpicContentCached();
-    const testName = 'FrontendDotcomRenderingEpic';
-    const campaign = 'frontend_dotcom_rendering_epic';
-    const variantName = pageTracking.clientName;
-
-    const testTracking: EpicTestTracking = {
-        abTestName: testName,
-        abTestVariant: variantName,
-        campaignCode: `gdnwb_copts_memco_${campaign}_${variantName}`,
-        campaignId: campaign,
-    };
-
-    const tracking: EpicTracking = {
-        ...pageTracking,
-        ...testTracking,
-    };
-
-    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory);
-    const { countryCode } = targeting;
-
-    const props = {
-        variant,
-        tracking,
-        numArticles,
-        countryCode,
-    };
-
-    logTargeting(`Renders Epic true for targeting: ${JSON.stringify(targeting)}`);
-
-    return componentAsResponse(getEpic(props), testTracking);
-};
-
-const buildDynamicEpic = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
 ): Promise<Response | null> => {
@@ -164,34 +109,15 @@ const buildDynamicEpic = async (
     return componentAsResponse(getEpic(props), testTracking);
 };
 
-const validator = new Validator(); // reuse as expensive to initialise
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const validatePayload = (body: any): EpicPayload => {
-    const validation = validator.validate(body, epicPayloadSchema);
-
-    if (!validation.valid) {
-        throw new ValidationError(validation.toString());
-    }
-
-    return body as EpicPayload;
-};
-
-const shouldSelectTestDynamically = (): boolean => process.env.ENABLE_DYNAMIC_TESTS === 'true';
-
 app.get(
     '/epic',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const { pageTracking, targeting } = testData;
-
-            const epic = shouldSelectTestDynamically()
-                ? await buildDynamicEpic(pageTracking, targeting)
-                : await buildEpic(pageTracking, targeting);
-
+            const epic = await buildEpic(pageTracking, targeting);
             const { html, css, js } = epic ?? { html: '', css: '', js: '' };
-            const htmlContent = renderHtmlDocument({ html, css, js });
-            res.send(htmlContent);
+            const htmlDoc = renderHtmlDocument({ html, css, js });
+            res.send(htmlDoc);
         } catch (error) {
             next(error);
         }
@@ -207,10 +133,7 @@ app.post(
             }
 
             const { tracking, targeting } = req.body;
-
-            const epic = shouldSelectTestDynamically()
-                ? await buildDynamicEpic(tracking, targeting)
-                : await buildEpic(tracking, targeting);
+            const epic = await buildEpic(tracking, targeting);
 
             // for response logging
             res.locals.didRenderEpic = !!epic;
@@ -262,7 +185,7 @@ app.post(
             referrerUrl: 'https://theguardian.com',
         };
 
-        const got = await buildDynamicEpic(sampleTracking, targeting);
+        const got = await buildEpic(sampleTracking, targeting);
 
         const notBothFalsy = expectedTest || got;
         const gotTestName = got?.meta?.abTestName;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -6,7 +6,7 @@ import { extractCritical } from 'emotion-server';
 import { renderHtmlDocument } from './utils/renderHtmlDocument';
 import { fetchDefaultEpicContent, fetchConfiguredEpicTests } from './api/contributionsApi';
 import { cacheAsync } from './lib/cache';
-import { contributionsEpicSlot, SlotComponent } from './components/ContributionsEpic';
+import { JsComponent, getEpic } from './components/ContributionsEpic';
 import {
     EpicPageTracking,
     EpicTestTracking,
@@ -66,9 +66,9 @@ const logTargeting = (message: string): void => {
     }
 };
 
-const componentAsResponse = (componentWrapper: SlotComponent, meta: EpicTestTracking): Response => {
-    const { component, js } = componentWrapper;
-    const { html, css } = extractCritical(renderToStaticMarkup(component));
+const componentAsResponse = (componentWrapper: JsComponent, meta: EpicTestTracking): Response => {
+    const { el, js } = componentWrapper;
+    const { html, css } = extractCritical(renderToStaticMarkup(el));
 
     return {
         html,
@@ -126,7 +126,7 @@ const buildEpic = async (
 
     logTargeting(`Renders Epic true for targeting: ${JSON.stringify(targeting)}`);
 
-    return componentAsResponse(contributionsEpicSlot(props), testTracking);
+    return componentAsResponse(getEpic(props), testTracking);
 };
 
 // Return the HTML and CSS from rendering the Epic to static markup
@@ -176,7 +176,7 @@ const buildDynamicEpic = async (
 
     logTargeting(`Renders Epic true for targeting: ${JSON.stringify(targeting)}`);
 
-    return componentAsResponse(contributionsEpicSlot(props), testTracking);
+    return componentAsResponse(getEpic(props), testTracking);
 };
 
 const validator = new Validator(); // reuse as expensive to initialise

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -24,6 +24,7 @@ import {
     logging as loggingMiddleware,
 } from './middleware';
 import { getAllHardcodedTests } from './tests';
+import { logTargeting } from './lib/logging';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -47,12 +48,6 @@ interface Response {
 }
 
 const [, fetchConfiguredEpicTestsCached] = cacheAsync(fetchConfiguredEpicTests, 60);
-
-const logTargeting = (message: string): void => {
-    if (process.env.LOG_TARGETING === 'true') {
-        console.log(message);
-    }
-};
 
 const componentAsResponse = (componentWrapper: JsComponent, meta: EpicTestTracking): Response => {
     const { el, js } = componentWrapper;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -128,75 +128,72 @@ app.post(
 );
 
 // TODO remove once migration complete
-app.post(
-    '/epic/compare-variant-decision',
-    async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        if (process.env.LOG_COMPARE_VARIANTS !== 'true') {
-            res.send('ignoring');
-            return;
-        }
+app.post('/epic/compare-variant-decision', async (req: express.Request, res: express.Response) => {
+    if (process.env.LOG_COMPARE_VARIANTS !== 'true') {
+        res.send('ignoring');
+        return;
+    }
 
-        const {
-            targeting,
-            expectedTest,
-            expectedVariant,
-            expectedCampaignCode,
-            expectedCampaignId,
-            frontendLog,
-        } = req.body;
+    const {
+        targeting,
+        expectedTest,
+        expectedVariant,
+        expectedCampaignCode,
+        expectedCampaignId,
+        frontendLog,
+    } = req.body;
 
-        // Ignore some manually defined tests in Frontend for now
-        const ignores = [
-            'FrontendDotcomRenderingEpic',
-            'RemoteRenderEpicRoundTwo',
-            'ContributionsEpicPrecontributionReminderRoundTwo',
-        ];
+    // Ignore some manually defined tests in Frontend for now
+    const ignores = [
+        'FrontendDotcomRenderingEpic',
+        'RemoteRenderEpicRoundTwo',
+        'ContributionsEpicPrecontributionReminderRoundTwo',
+    ];
 
-        if (ignores.includes(expectedTest)) {
-            res.send('ignoring');
-            return;
-        }
+    if (ignores.includes(expectedTest)) {
+        res.send('ignoring');
+        return;
+    }
 
-        // We need these to satisfy the buildDynamicEpic interface, but it
-        // doesn't matter what values we use
-        const sampleTracking = {
-            ophanPageId: 'xxxxxxxxxxxxx',
-            ophanComponentId: 'ACQUISITIONS_EPIC',
-            platformId: 'GUARDIAN_WEB',
-            clientName: 'xxx',
-            referrerUrl: 'https://theguardian.com',
-        };
+    // We need these to satisfy the buildDynamicEpic interface, but it
+    // doesn't matter what values we use
+    const sampleTracking = {
+        ophanPageId: 'xxxxxxxxxxxxx',
+        ophanComponentId: 'ACQUISITIONS_EPIC',
+        platformId: 'GUARDIAN_WEB',
+        clientName: 'xxx',
+        referrerUrl: 'https://theguardian.com',
+    };
 
-        const got = await buildEpic(sampleTracking, targeting);
+    const got = await buildEpic(sampleTracking, targeting);
 
-        const notBothFalsy = expectedTest || got;
-        const gotTestName = got?.meta?.abTestName;
-        const gotVariantName = got?.meta?.abTestVariant;
-        const gotCampaignCode = got?.meta?.campaignCode;
-        const gotCampaignId = got?.meta?.campaignId;
+    const notBothFalsy = expectedTest || got;
+    const gotTestName = got?.meta?.abTestName;
+    const gotVariantName = got?.meta?.abTestVariant;
+    const gotCampaignCode = got?.meta?.campaignCode;
+    const gotCampaignId = got?.meta?.campaignId;
 
-        const notTheSame =
-            gotTestName !== expectedTest ||
-            gotVariantName !== expectedVariant ||
-            gotCampaignCode !== expectedCampaignCode ||
-            gotCampaignId !== expectedCampaignId;
+    const notTheSame =
+        gotTestName !== expectedTest ||
+        gotVariantName !== expectedVariant ||
+        gotCampaignCode !== expectedCampaignCode ||
+        gotCampaignId !== expectedCampaignId;
 
-        if (notBothFalsy && notTheSame) {
-            console.log(
-                'comparison failed with data: ' +
-                    JSON.stringify({
-                        status: 'comparison failed',
-                        got: `${gotTestName}:${gotVariantName}:${gotCampaignCode}:${gotCampaignId}`,
-                        want: `${expectedTest}:${expectedVariant}:${expectedCampaignCode}:${expectedCampaignId}`,
-                        targeting,
-                        frontendLog,
-                    }),
-            );
-        }
+    if (notBothFalsy && notTheSame) {
+        console.log(
+            'comparison failed with data: ' +
+                JSON.stringify({
+                    status: 'comparison failed',
+                    got: `${gotTestName}:${gotVariantName}:${gotCampaignCode}:${gotCampaignId}`,
+                    want: `${expectedTest}:${expectedVariant}:${expectedCampaignCode}:${expectedCampaignId}`,
+                    targeting,
+                    frontendLog,
+                }),
+        );
+    }
 
-        res.send('thanks');
-    },
-);
+    res.send('thanks');
+});
 
 app.use(errorHandlingMiddleware);
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -143,7 +143,6 @@ app.post('/epic/compare-variant-decision', async (req: express.Request, res: exp
         frontendLog,
     } = req.body;
 
-    // Ignore some manually defined tests in Frontend for now
     const ignores = [
         'FrontendDotcomRenderingEpic',
         'RemoteRenderEpicRoundTwo',
@@ -155,9 +154,7 @@ app.post('/epic/compare-variant-decision', async (req: express.Request, res: exp
         return;
     }
 
-    // We need these to satisfy the buildDynamicEpic interface, but it
-    // doesn't matter what values we use
-    const sampleTracking = {
+    const fakeTracking = {
         ophanPageId: 'xxxxxxxxxxxxx',
         ophanComponentId: 'ACQUISITIONS_EPIC',
         platformId: 'GUARDIAN_WEB',
@@ -165,7 +162,7 @@ app.post('/epic/compare-variant-decision', async (req: express.Request, res: exp
         referrerUrl: 'https://theguardian.com',
     };
 
-    const got = await buildEpic(sampleTracking, targeting);
+    const got = await buildEpic(fakeTracking, targeting);
 
     const notBothFalsy = expectedTest || got;
     const gotTestName = got?.meta?.abTestName;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -34,7 +34,6 @@ const schemaPath = path.join(__dirname, 'schemas', 'epicPayload.schema.json');
 const epicPayloadSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
 console.log('Loaded epic payload JSON schema');
 
-// Use middleware
 const app = express();
 app.use(express.json({ limit: '50mb' }));
 
@@ -78,7 +77,6 @@ const componentAsResponse = (componentWrapper: JsComponent, meta: EpicTestTracki
     };
 };
 
-// Return the HTML and CSS from rendering the Epic to static markup
 const buildEpic = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
@@ -94,7 +92,7 @@ const buildEpic = async (
     const variant = await fetchDefaultEpicContentCached();
     const testName = 'FrontendDotcomRenderingEpic';
     const campaign = 'frontend_dotcom_rendering_epic';
-    const variantName = pageTracking.clientName; // dcr || frontend
+    const variantName = pageTracking.clientName;
 
     const testTracking: EpicTestTracking = {
         abTestName: testName,
@@ -108,13 +106,7 @@ const buildEpic = async (
         ...testTracking,
     };
 
-    // Hardcoding the number of weeks to match common values used in the tests.
-    // We know the copy refers to 'articles viewed in past 4 months' and this
-    // will show a count for the past year, but this seems to mirror Frontend
-    // and an accurate match between the view counts used for variant selection
-    // and template rendering is not necessarily essential.
-    const periodInWeeks = 52;
-    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory, periodInWeeks);
+    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory);
     const { countryCode } = targeting;
 
     const props = {
@@ -129,7 +121,6 @@ const buildEpic = async (
     return componentAsResponse(getEpic(props), testTracking);
 };
 
-// Return the HTML and CSS from rendering the Epic to static markup
 const buildDynamicEpic = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
@@ -158,13 +149,7 @@ const buildDynamicEpic = async (
         ...testTracking,
     };
 
-    // Hardcoding the number of weeks to match common values used in the tests.
-    // We know the copy refers to 'articles viewed in past 4 months' and this
-    // will show a count for the past year, but this seems to mirror Frontend
-    // and an accurate match between the view counts used for variant selection
-    // and template rendering is not necessarily essential.
-    const periodInWeeks = 52;
-    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory, periodInWeeks);
+    const numArticles = getArticleViewCountForWeeks(targeting.weeklyArticleHistory);
     const { countryCode } = targeting;
 
     const props = {
@@ -310,8 +295,8 @@ app.post(
 
 app.use(errorHandlingMiddleware);
 
-// If local then don't wrap in serverless
 const PORT = process.env.PORT || 3030;
+
 if (process.env.NODE_ENV === 'development') {
     app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
 } else {


### PR DESCRIPTION
* remove default epic (now that we are ready to go all variants)
* tidyup server.tsx and controllers
* fix all eslint warnings

On the second, the controllers and server.tsx have got pretty cluttered, and some of the code was a bit hard to read. In general I've tried to do things like:

* move out logic from controllers and keep them higher-level and easy to read
* rename things for clarity and concision (lengthier names the further from point of use, shorter names when scoped only to a function/used locally, etc.)
* remove or reword unnecessary comments

Much of this is subjective, but I think in this case the file needed some love/got to the point where some pruning was required.

It's probably easier to check it out and see the overall picture than review line by line - although I have mostly tried to keep commits sensible.