### PR TITLE
Start defining and using factories

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     roots: ['<rootDir>/src'],
+    modulePathIgnorePatterns: ['<rootDir>/src/factories/test.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.0",
     "fetch-mock": "^8.3.1",
+    "fishery": "^0.3.0",
     "husky": "^4.2.2",
     "inquirer": "^7.0.3",
     "jest": "^24.9.0",

--- a/src/components/EpicButtons.test.tsx
+++ b/src/components/EpicButtons.test.tsx
@@ -5,22 +5,18 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import testData from './ContributionsEpic.testData';
+import { factories } from '../factories';
 
 import { EpicButtons } from './EpicButtons';
 
 describe('EpicButtons', () => {
     it('Renders the primary button', () => {
-        const variant = {
-            ...testData.content,
-            name: 'Example',
-            showTicker: false,
+        const variant = factories.variant.build({
             cta: {
                 text: 'Button text!',
-                baseUrl: 'https://support.theguardian.com/support',
             },
-        };
-        const tracking = testData.tracking;
+        });
+        const tracking = factories.tracking.build();
 
         render(<EpicButtons variant={variant} tracking={tracking} />);
 
@@ -28,13 +24,14 @@ describe('EpicButtons', () => {
     });
 
     it('Renders nothing when no primary CTA', () => {
-        const variant = {
-            ...testData.content,
-            name: 'Example',
-            showTicker: false,
+        const variant = factories.variant.build({
             cta: undefined,
-        };
-        const tracking = testData.tracking;
+            secondaryCta: {
+                text: 'Secondary button!',
+                baseUrl: 'https://support.theguardian.com/support',
+            },
+        });
+        const tracking = factories.tracking.build();
 
         const { queryByTestId } = render(<EpicButtons variant={variant} tracking={tracking} />);
 
@@ -42,10 +39,7 @@ describe('EpicButtons', () => {
     });
 
     it('Does not render the reminder button when secondary CTA present', () => {
-        const variant = {
-            ...testData.content,
-            name: 'Example',
-            showTicker: false,
+        const variant = factories.variant.build({
             cta: {
                 text: 'Button text!',
                 baseUrl: 'https://support.theguardian.com/support',
@@ -59,8 +53,8 @@ describe('EpicButtons', () => {
                 reminderDateAsString: 'June',
                 reminderDate: '2020-06-01T09:30:00',
             },
-        };
-        const tracking = testData.tracking;
+        });
+        const tracking = factories.tracking.build();
 
         const { queryByText } = render(<EpicButtons variant={variant} tracking={tracking} />);
 
@@ -69,10 +63,7 @@ describe('EpicButtons', () => {
     });
 
     it('Renders the reminder button when secondary CTA is not present', () => {
-        const variant = {
-            ...testData.content,
-            name: 'Example',
-            showTicker: false,
+        const variant = factories.variant.build({
             cta: {
                 text: 'Button text!',
                 baseUrl: 'https://support.theguardian.com/support',
@@ -83,8 +74,8 @@ describe('EpicButtons', () => {
                 reminderDateAsString: 'June',
                 reminderDate: '2020-06-01T09:30:00',
             },
-        };
-        const tracking = testData.tracking;
+        });
+        const tracking = factories.tracking.build();
 
         render(<EpicButtons variant={variant} tracking={tracking} />);
 

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,0 +1,14 @@
+import { register } from 'fishery';
+import variant from './variant';
+import test from './test';
+import targeting from './targeting';
+import { pageTracking, testTracking, tracking } from './tracking';
+
+export const factories = register({
+    pageTracking,
+    targeting,
+    test,
+    testTracking,
+    tracking,
+    variant,
+});

--- a/src/factories/targeting.ts
+++ b/src/factories/targeting.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery';
+import { EpicTargeting } from '../components/ContributionsEpicTypes';
+
+export default Factory.define<EpicTargeting>(() => ({
+    contentType: 'Article',
+    sectionName: 'culture',
+    shouldHideReaderRevenue: false,
+    isMinuteArticle: false,
+    isPaidContent: false,
+    isRecurringContributor: false,
+    tags: [],
+    showSupportMessaging: true,
+}));

--- a/src/factories/test.ts
+++ b/src/factories/test.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery';
+import { Test } from '../lib/variants';
+
+export default Factory.define<Test>(({ factories }) => ({
+    name: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
+    isOn: true,
+    locations: [],
+    tagIds: ['environment/series/the-polluters', 'environment/environment'],
+    sections: ['environment'],
+    excludedTagIds: ['world/coronavirus-outbreak'],
+    excludedSections: [],
+    alwaysAsk: true,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'Everyone',
+    isLiveBlog: false,
+    hasCountryName: false,
+    highPriority: false,
+    useLocalViewLog: false,
+    variants: factories.variant.buildList(1),
+}));

--- a/src/factories/tracking.ts
+++ b/src/factories/tracking.ts
@@ -1,0 +1,27 @@
+import { Factory } from 'fishery';
+import {
+    EpicTestTracking,
+    EpicPageTracking,
+    EpicTracking,
+} from '../components/ContributionsEpicTypes';
+
+export const pageTracking = Factory.define<EpicPageTracking>(() => ({
+    ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+    ophanComponentId: 'ACQUISITIONS_EPIC',
+    platformId: 'GUARDIAN_WEB',
+    clientName: 'dcr',
+    referrerUrl:
+        'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+}));
+
+export const testTracking = Factory.define<EpicTestTracking>(() => ({
+    campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
+    campaignId: 'remote_epic_test',
+    abTestName: 'remote_epic_test',
+    abTestVariant: 'api',
+}));
+
+export const tracking = Factory.define<EpicTracking>(({ factories }) => ({
+    ...factories.pageTracking.build(),
+    ...factories.testTracking.build(),
+}));

--- a/src/factories/variant.ts
+++ b/src/factories/variant.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'fishery';
+import { Variant } from '../lib/variants';
+
+export default Factory.define<Variant>(() => ({
+    name: 'Example Variant',
+    heading: 'Since you’re here...',
+    paragraphs: [
+        '... we have a small favour to ask. More people, like you, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+        'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
+    ],
+    highlightedText:
+        'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
+    backgroundImageUrl:
+        'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+    showTicker: false,
+    cta: {
+        text: 'Contribute to The Guardian!',
+        baseUrl: 'https://support.theguardian.com/support',
+    },
+}));

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -1,33 +1,21 @@
 import { shouldNotRenderEpic, shouldThrottle } from './targeting';
-import { EpicTargeting } from '../components/ContributionsEpicTypes';
-import testData from '../components/ContributionsEpic.testData';
+import { factories } from '../factories';
 
 describe('shouldNotRenderEpic', () => {
-    const meta: EpicTargeting = testData.targeting;
-
     it('returns true for non-article', () => {
-        const data = { ...meta, contentType: 'Liveblog' };
+        const data = factories.targeting.build({ contentType: 'Liveblog' });
         const got = shouldNotRenderEpic(data);
         expect(got).toBe(true);
     });
 
     it('returns true for blacklisted section', () => {
-        const data = { ...meta, sectionName: 'careers' };
+        const data = factories.targeting.build({ sectionName: 'careers' });
         const got = shouldNotRenderEpic(data);
         expect(got).toBe(true);
     });
 
     it('returns false for valid data', () => {
-        const data = {
-            contentType: 'Article',
-            sectionName: 'culture',
-            shouldHideReaderRevenue: false,
-            isMinuteArticle: false,
-            isPaidContent: false,
-            isRecurringContributor: false,
-            tags: [],
-            showSupportMessaging: true,
-        };
+        const data = factories.targeting.build();
         const got = shouldNotRenderEpic(data);
         expect(got).toBe(false);
     });

--- a/src/lib/tracking.test.ts
+++ b/src/lib/tracking.test.ts
@@ -1,14 +1,10 @@
 import { buildCampaignCode, addTrackingParams } from './tracking';
-import { Test, Variant } from '../lib/variants';
-import { configuredTests } from '../api/contributionsApi.testData';
+import { factories } from '../factories/';
 
 describe('addTrackingParams', () => {
     it('should return a correctly formatted URL', () => {
-        const dummyMeta = {
+        const trackingData = factories.tracking.build({
             ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
-            ophanComponentId: 'ACQUISITIONS_EPIC',
-            platformId: 'GUARDIAN_WEB',
-            clientName: 'dcr',
             campaignCode:
                 'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
             campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
@@ -16,29 +12,23 @@ describe('addTrackingParams', () => {
             abTestVariant: 'v2_stay_quiet',
             referrerUrl:
                 'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
-        };
+        });
         const buttonBaseUrl = 'https://support.theguardian.com/contribute/climate-pledge-2019';
+
+        const got = addTrackingParams(buttonBaseUrl, trackingData);
 
         const want =
             'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
-
-        const got = addTrackingParams(buttonBaseUrl, dummyMeta);
-
         expect(got).toEqual(want);
     });
 });
 
 describe('buildCampaignCode', () => {
     it('returns the correct campaign code for the test and variant', () => {
-        const test: Test = {
-            ...configuredTests.tests[0],
+        const test = factories.test.build({
             name: 'enviro_fossil_fuel_r2_Epic__no_article_count',
-        };
-
-        const variant: Variant = {
-            ...configuredTests.tests[0].variants[0],
-            name: 'Control',
-        };
+        });
+        const variant = factories.variant.build({ name: 'Control' });
 
         const campaignCode = buildCampaignCode(test, variant);
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { app } from './server';
 import testData from './components/ContributionsEpic.testData';
 import { configuredTests } from './api/contributionsApi.testData';
+import { factories } from './factories';
 
 jest.mock('./api/contributionsApi', () => {
     return {
@@ -20,7 +21,8 @@ jest.mock('./api/contributionsApi', () => {
 
 describe('POST /epic', () => {
     it('should return an epic', async () => {
-        const { pageTracking, targeting } = testData;
+        const { targeting } = testData;
+        const pageTracking = factories.pageTracking.build();
 
         const res = await request(app)
             .post('/epic')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
         "outDir": "dist"
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "**/*.test.ts"]
+    "exclude": ["node_modules", "**/*.test.ts", "src/factories/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5875,6 +5875,13 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
+fishery@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/fishery/-/fishery-0.3.0.tgz#8f1d24f69600e38e0707943e62300cad42ae1f16"
+  integrity sha512-hY2LTDq213KquLftAVgvQOcZmtx5Kr0JadWvNJgnT0NkjH0MB+Xvg6XIxbMFwkDed0CyYpcAUThgj0qWVigmbw==
+  dependencies:
+    lodash.merge "^4.6.2"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -7974,6 +7981,11 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Within our test suite the test data we use is a little spread out in some cases, and sometimes requires a bit of manual piecing together to create a valid object.

This PR introduces the [fishery](https://github.com/thoughtbot/fishery) library for defining factories for common types of data. Rather than go ahead and switch over wholesale I picked a single test file and migrated that to use a new variant factory I've defined. If we like it then we can migrate other test files (either in this or a separate PR).

I think the benefits of factories are:

* There's a single place where you can go to build objects for tests
* The factories provide sensible defaults and so you only have to specify the fields you care about in your test, reducing noise

Fishery itself is built with TypeScript in mind, so we can be confident that factories return valid objects.