### PR TITLE
Remove unused var

### DIFF
--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -227,7 +227,7 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
 // https://github.com/guardian/frontend/pull/22546
 export const noArticleViewedSettings: Filter = {
     id: 'noArticleViewedSettings',
-    test: (test, _): boolean => {
+    test: (test): boolean => {
         return !test.articlesViewedSettings;
     },
 };


### PR DESCRIPTION
This is a rare case where a PR builds okay, but fails when in master. Because https://github.com/guardian/contributions-service/pulls?q=is%3Apr+is%3Aclosed fails a new lint config I added and my PR had not been rebased against it.