### PR TITLE
New endpoint for AMP epic json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@guardian/src-svgs": "^0.18.1",
     "@guardian/src-text-input": "^0.18.1",
     "@types/babel__standalone": "^7.1.2",
+    "amp-toolbox-cors": "^1.2.0-alpha.2",
     "aws-serverless-express": "^3.3.6",
     "cors": "^2.8.5",
     "emotion": "^10.0.27",

--- a/src/amp-toolbox-cors.d.ts
+++ b/src/amp-toolbox-cors.d.ts
@@ -1,0 +1,1 @@
+declare module 'amp-toolbox-cors';

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -201,6 +201,7 @@ app.get(
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
             const response = ampDefaultEpic(countryCode);
 
+            // The cache key in fastly is the X-GU-GeoIP-Country-Code header
             res.setHeader('Surrogate-Control', 'max-age=300');
             res.setHeader('Cache-Control', 'max-age=60');
             res.send(response);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -1,4 +1,5 @@
 import express from 'express';
+import ampCors from 'amp-toolbox-cors';
 import awsServerlessExpress from 'aws-serverless-express';
 import { Context } from 'aws-lambda';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -32,6 +33,10 @@ app.use(express.json({ limit: '50mb' }));
 // Note allows *all* cors. We may want to tighten this later.
 app.use(cors());
 app.options('*', cors());
+
+app.use(ampCors({
+    sourceOriginPattern: /.*\/amp\/epic$/
+}));
 
 app.use(loggingMiddleware);
 
@@ -204,6 +209,7 @@ app.get(
             // The cache key in fastly is the X-GU-GeoIP-Country-Code header
             res.setHeader('Surrogate-Control', 'max-age=300');
             res.setHeader('Cache-Control', 'max-age=60');
+
             res.send(response);
         } catch (error) {
             next(error);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -24,7 +24,7 @@ import {
 } from './middleware';
 import { getAllHardcodedTests } from './tests';
 import { logTargeting } from './lib/logging';
-import { ampDefaultEpic } from "./tests/ampDefaultEpic";
+import { ampDefaultEpic } from './tests/ampDefaultEpic';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -24,6 +24,7 @@ import {
 } from './middleware';
 import { getAllHardcodedTests } from './tests';
 import { logTargeting } from './lib/logging';
+import {ampDefaultEpic} from "./tests/ampDefaultEpic";
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -191,6 +192,19 @@ app.post('/epic/compare-variant-decision', async (req: express.Request, res: exp
 
     res.send('thanks');
 });
+
+app.get(
+    '/amp/epic',
+    async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        try {
+            const countryCode = req.header('X-GU-GeoIP-Country-Code');
+            const response = ampDefaultEpic(countryCode);
+            res.send(response);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
 
 app.use(errorHandlingMiddleware);
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -34,9 +34,11 @@ app.use(express.json({ limit: '50mb' }));
 app.use(cors());
 app.options('*', cors());
 
-app.use(ampCors({
-    sourceOriginPattern: /.*\/amp\/epic$/
-}));
+app.use(
+    ampCors({
+        sourceOriginPattern: /.*\/amp\/epic$/,
+    }),
+);
 
 app.use(loggingMiddleware);
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -24,7 +24,7 @@ import {
 } from './middleware';
 import { getAllHardcodedTests } from './tests';
 import { logTargeting } from './lib/logging';
-import {ampDefaultEpic} from "./tests/ampDefaultEpic";
+import { ampDefaultEpic } from "./tests/ampDefaultEpic";
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -197,6 +197,7 @@ app.get(
     '/amp/epic',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
+            // We use the fastly geo header for determining the correct currency symbol
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
             const response = ampDefaultEpic(countryCode);
             res.send(response);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -200,6 +200,9 @@ app.get(
             // We use the fastly geo header for determining the correct currency symbol
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
             const response = ampDefaultEpic(countryCode);
+
+            res.setHeader('Surrogate-Control', 'max-age=300');
+            res.setHeader('Cache-Control', 'max-age=60');
             res.send(response);
         } catch (error) {
             next(error);

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,4 +1,4 @@
-import { getLocalCurrencySymbol } from "../lib/geolocation";
+import { getLocalCurrencySymbol } from '../lib/geolocation';
 
 export const ampDefaultEpic = (geolocation?: string) => {
     const currencySymbol = getLocalCurrencySymbol(geolocation);

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,0 +1,15 @@
+import {getLocalCurrencySymbol} from "../lib/geolocation";
+
+export const ampDefaultEpic = (geolocation?: string) => {
+    const currencySymbol = getLocalCurrencySymbol(geolocation);
+    return ({
+        heading: 'Since you’re here...',
+        paragraphs: [
+            '… we’re asking readers like you to support our open, independent journalism. News is under threat just when we need it the most. Growing numbers of readers are seeking authoritative, fact-based reporting on one of the biggest challenges we have faced in our lifetime. But advertising revenue is plummeting, and many news organizations are facing an existential threat. We need you to help fill the gap.',
+            'We believe every one of us deserves equal access to quality, independent, trustworthy journalism. So, unlike many others, we made a different choice: to keep Guardian journalism open for all, regardless of where they live or what they can afford to pay. This would not be possible without financial contributions from readers who now support our work from 180 countries around the world.',
+            'The Guardian’s independence means we can set our own agenda and voice our own opinions. Our journalism is free from commercial and political bias – never influenced by billionaire owners or shareholders.',
+            'We need your support so we can keep delivering quality journalism that’s open and independent.'
+        ],
+        highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
+    });
+};

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,6 +1,6 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
 
-export const ampDefaultEpic = (geolocation?: string) => {
+export const ampDefaultEpic: object = (geolocation?: string) => {
     const currencySymbol = getLocalCurrencySymbol(geolocation);
     return {
         heading: 'Since you’re here...',

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,8 +1,8 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
 
-export const ampDefaultEpic: object = (geolocation?: string) => {
+export function ampDefaultEpic(geolocation?: string): string {
     const currencySymbol = getLocalCurrencySymbol(geolocation);
-    return {
+    const epic = {
         heading: 'Since you’re here...',
         paragraphs: [
             '… we’re asking readers like you to support our open, independent journalism. News is under threat just when we need it the most. Growing numbers of readers are seeking authoritative, fact-based reporting on one of the biggest challenges we have faced in our lifetime. But advertising revenue is plummeting, and many news organizations are facing an existential threat. We need you to help fill the gap.',
@@ -12,4 +12,5 @@ export const ampDefaultEpic: object = (geolocation?: string) => {
         ],
         highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
     };
-};
+    return JSON.stringify(epic);
+}

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,15 +1,15 @@
-import {getLocalCurrencySymbol} from "../lib/geolocation";
+import { getLocalCurrencySymbol } from "../lib/geolocation";
 
 export const ampDefaultEpic = (geolocation?: string) => {
     const currencySymbol = getLocalCurrencySymbol(geolocation);
-    return ({
+    return {
         heading: 'Since you’re here...',
         paragraphs: [
             '… we’re asking readers like you to support our open, independent journalism. News is under threat just when we need it the most. Growing numbers of readers are seeking authoritative, fact-based reporting on one of the biggest challenges we have faced in our lifetime. But advertising revenue is plummeting, and many news organizations are facing an existential threat. We need you to help fill the gap.',
             'We believe every one of us deserves equal access to quality, independent, trustworthy journalism. So, unlike many others, we made a different choice: to keep Guardian journalism open for all, regardless of where they live or what they can afford to pay. This would not be possible without financial contributions from readers who now support our work from 180 countries around the world.',
             'The Guardian’s independence means we can set our own agenda and voice our own opinions. Our journalism is free from commercial and political bias – never influenced by billionaire owners or shareholders.',
-            'We need your support so we can keep delivering quality journalism that’s open and independent.'
+            'We need your support so we can keep delivering quality journalism that’s open and independent.',
         ],
         highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
-    });
+    };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,6 +2675,37 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+amp-toolbox-cache-list@^1.2.0-alpha.2:
+  version "1.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/amp-toolbox-cache-list/-/amp-toolbox-cache-list-1.2.0-alpha.2.tgz#820a8daecfddb3c8189a25bc7abb027a7b13ce97"
+  integrity sha512-iiXrO3tHTG5RvrXywoloKYucOaGoNk4zoXgqrM/r2JDSuk+WvuYsB6SsPk+zq8+VmKmnp4lp5gYgmZM3hubmEQ==
+  dependencies:
+    amp-toolbox-core "^1.2.0-alpha.2"
+
+amp-toolbox-cache-url@^1.2.0-alpha.2:
+  version "1.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/amp-toolbox-cache-url/-/amp-toolbox-cache-url-1.2.0-alpha.2.tgz#3ddfe9f7a32027e258bc98e880bf928809c399e8"
+  integrity sha512-UBuTpJCsxRqXsshM3dR15lNcZj9bmwywDLvspJwi6m9hAOIsrHEQxNJpOko5nHsfURk6OKBl6csjylfZxi6EXg==
+  dependencies:
+    punycode "2.1.1"
+    url-parse "1.4.7"
+
+amp-toolbox-core@^1.2.0-alpha.2:
+  version "1.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/amp-toolbox-core/-/amp-toolbox-core-1.2.0-alpha.2.tgz#6ce061e832a71ed2474f230e205781c62930500f"
+  integrity sha512-rc7iDepmJc+RIH/2qzaFt2BvfCs8Itdd7jkNByr/zDFhA94yAQMZc7Hi00fCJaiL/Hxlk9XQ4jaXFYxu2uRZ9A==
+  dependencies:
+    node-fetch "2.6.0"
+
+amp-toolbox-cors@^1.2.0-alpha.2:
+  version "1.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/amp-toolbox-cors/-/amp-toolbox-cors-1.2.0-alpha.2.tgz#6977b2138b09d9d60581eea91cfa3542d55f3dc5"
+  integrity sha512-/QukTqugYYYf8LdrqiM8taGXuFprm3N7asCyl2tEfJ9k54gplaJQjWRlhm0DxDdm9xqaZ2hTDvTEu63F/L4M3w==
+  dependencies:
+    amp-toolbox-cache-list "^1.2.0-alpha.2"
+    amp-toolbox-cache-url "^1.2.0-alpha.2"
+    amp-toolbox-core "^1.2.0-alpha.2"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -8503,6 +8534,11 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-fetch@2.6.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -8510,11 +8546,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -9560,15 +9591,15 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
+punycode@2.1.1, punycode@^2.1.0, punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 q@^1.1.2:
   version "1.5.1"
@@ -11796,7 +11827,7 @@ url-loader@^2.0.1:
     mime "^2.4.4"
     schema-utils "^2.5.0"
 
-url-parse@^1.4.3:
+url-parse@1.4.7, url-parse@^1.4.3:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
We're adding the epic to google AMP articles.
The AMP page will request the json for the epic from the contributions-service.
To begin with we're doing the same hard-coded epic across all articles. Later on we will implement targeted epics.

The currency symbol in the epic copy is determined using the fastly geo header, so that all the client has to do is render the copy.