### PR TITLE
Prepend epic_ to campaign ID

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -39,7 +39,7 @@ describe('POST /epic', () => {
             abTestVariant: 'Control',
             campaignCode:
                 'gdnwb_copts_memco_2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count_Control',
-            campaignId: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
+            campaignId: 'epic_2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
         });
     });
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -77,7 +77,7 @@ const buildEpic = async (
         abTestName: test.name,
         abTestVariant: variant.name,
         campaignCode: buildCampaignCode(test, variant),
-        campaignId: test.campaignId || test.name,
+        campaignId: `epic_${test.campaignId || test.name}`,
     };
 
     const props = {


### PR DESCRIPTION
See https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L349 .

https://github.com/guardian/frontend/pull/22552 depends on this.