### PR TITLE
Add CTA to AMP epic response

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -225,6 +225,7 @@ app.get(
             // The cache key in fastly is the X-GU-GeoIP-Country-Code header
             res.setHeader('Surrogate-Control', 'max-age=300');
             res.setHeader('Cache-Control', 'max-age=60');
+            res.setHeader('Content-Type', 'application/json');
 
             res.send(JSON.stringify(response));
         } catch (error) {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -226,7 +226,7 @@ app.get(
             res.setHeader('Surrogate-Control', 'max-age=300');
             res.setHeader('Cache-Control', 'max-age=60');
 
-            res.send(response);
+            res.send(JSON.stringify(response));
         } catch (error) {
             next(error);
         }

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -28,6 +28,7 @@ export function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
                 highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
                 cta: {
                     text: 'Support the Guardian',
+                    // TODO - get tracking code
                     baseUrl: 'https://support.theguardian.com/contribute',
                 },
             },

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,8 +1,20 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
+import { Cta } from '../lib/variants';
 
-export function ampDefaultEpic(geolocation?: string): string {
+interface AMPEpic {
+    heading?: string;
+    paragraphs: string[];
+    highlightedText?: string;
+    cta: Cta;
+}
+
+interface AMPEpicResponse {
+    items: AMPEpic[];
+}
+
+export function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
     const currencySymbol = getLocalCurrencySymbol(geolocation);
-    const epic = {
+    return {
         items: [
             {
                 heading: 'Since you’re here...',
@@ -13,8 +25,11 @@ export function ampDefaultEpic(geolocation?: string): string {
                     'We need your support so we can keep delivering quality journalism that’s open and independent.',
                 ],
                 highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
+                cta: {
+                    text: 'Support the Guardian',
+                    baseUrl: 'https://support.theguardian.com/contribute',
+                },
             },
         ],
     };
-    return JSON.stringify(epic);
 }

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -8,6 +8,7 @@ interface AMPEpic {
     cta: Cta;
 }
 
+// See https://amp.dev/documentation/components/amp-list/
 interface AMPEpicResponse {
     items: AMPEpic[];
 }


### PR DESCRIPTION
Also define a `AMPEpic` type, a stripped down version of the standard epic test type.
This endpoint does not return tests, as the client will not be able to select a variant from a test.