### PR TITLE
Add tracking params to AMP url

### DIFF
--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -14,6 +14,7 @@ interface AMPEpicResponse {
 }
 
 export function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
+    const campaignCode = 'AMP_EPIC_MAY2020';
     const currencySymbol = getLocalCurrencySymbol(geolocation);
     return {
         items: [
@@ -29,7 +30,7 @@ export function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
                 cta: {
                     text: 'Support the Guardian',
                     // TODO - get tracking code
-                    baseUrl: 'https://support.theguardian.com/contribute',
+                    baseUrl: `https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22GOOGLE_AMP%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22componentId%22%3A%22${campaignCode}%22%2C%22campaignCode%22%3A%22${campaignCode}%22%7D&INTCMP=${campaignCode}`,
                 },
             },
         ],


### PR DESCRIPTION
Here's how they look in support-frontend's redux store:
![Screen Shot 2020-05-14 at 10 20 26](https://user-images.githubusercontent.com/1513454/81917021-8c6c5b80-95cc-11ea-804a-4a57f22f01d2.png)

I'm not sure it's going to be possible to include the `referrerUrl`, but this can be investigated later