### PR TITLE
AMP epic: return tracking params as fields

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -238,7 +238,7 @@ app.get(
 
 app.use(errorHandlingMiddleware);
 
-const PORT = process.env.PORT || 3030;
+const PORT = process.env.PORT || 8080;
 
 if (process.env.NODE_ENV === 'development') {
     app.listen(PORT, () => console.log(`Listening on port ${PORT}`));

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -238,7 +238,7 @@ app.get(
 
 app.use(errorHandlingMiddleware);
 
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 3030;
 
 if (process.env.NODE_ENV === 'development') {
     app.listen(PORT, () => console.log(`Listening on port ${PORT}`));

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,11 +1,11 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
 
 interface AMPCta {
-    text: string,
-    baseUrl: string,    // deprecated, still here temporarily for backwards compatibility
-    url: string,
-    componentId: string,
-    campaignCode: string,
+    text: string;
+    baseUrl: string; // deprecated, still here temporarily for backwards compatibility
+    url: string;
+    componentId: string;
+    campaignCode: string;
 }
 
 interface AMPEpic {

--- a/src/tests/ampDefaultEpic.ts
+++ b/src/tests/ampDefaultEpic.ts
@@ -1,11 +1,18 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
-import { Cta } from '../lib/variants';
+
+interface AMPCta {
+    text: string,
+    baseUrl: string,    // deprecated, still here temporarily for backwards compatibility
+    url: string,
+    componentId: string,
+    campaignCode: string,
+}
 
 interface AMPEpic {
     heading?: string;
     paragraphs: string[];
     highlightedText?: string;
-    cta: Cta;
+    cta: AMPCta;
 }
 
 // See https://amp.dev/documentation/components/amp-list/
@@ -29,8 +36,10 @@ export function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
                 highlightedText: `Support the Guardian from as little as ${currencySymbol}1 – and it only takes a minute. Thank you.`,
                 cta: {
                     text: 'Support the Guardian',
-                    // TODO - get tracking code
                     baseUrl: `https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22GOOGLE_AMP%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22componentId%22%3A%22${campaignCode}%22%2C%22campaignCode%22%3A%22${campaignCode}%22%7D&INTCMP=${campaignCode}`,
+                    url: 'https://support.theguardian.com/contribute',
+                    campaignCode: campaignCode,
+                    componentId: campaignCode,
                 },
             },
         ],


### PR DESCRIPTION
Previously we returned the full epic link url, with tracking params, as `baseUrl` (which is not a very good name for it, but I used the existing cta model).

But we want the client to be able to insert a `referrerUrl` field into the tracking params. The proper way to do this is to have `contributions-service` return the parts that make up the tracking params, and let the client construct the url query string itself.

I've left `baseUrl` in for now, but it can be removed after the migration.