### PR TITLE
Fix didRenderEpic value

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -217,7 +217,7 @@ app.post(
             }
 
             // for response logging
-            res.locals.didRenderEpic = !!response;
+            res.locals.didRenderEpic = !!response.data;
             res.locals.clientName = tracking.clientName;
 
             res.send(response);


### PR DESCRIPTION
## What does this change?

Currently we're reporting that we rendered an epic 100% of the time, since here response is always truthy. The response value here now has the relevant epic data nested under a data property already, so it's that we need to inspect to determine if an epic was "rendered" (that term might need revisiting now we're switching to the data approach).

## How can we measure success?

Correct reporting of `didRenderEpic` in Kibana.