### PR TITLE
Beginnings of a banner component

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,16 +18,19 @@ const tsOpts = {
 };
 
 const globals = {
-    react: 'automat.react',
-    emotion: 'automat.emotion', // TODO remove this dependency
-    '@emotion/core': 'automat.emotionCore',
-    'emotion-theming': 'automat.emotionTheming',
+    react: 'guardian.automat.react',
+    emotion: 'guardian.automat.emotion', // TODO remove this dependency
+    '@emotion/core': 'guardian.automat.emotionCore',
+    'emotion-theming': 'guardian.automat.emotionTheming',
 };
 
 export default {
-    input: 'src/components/modules/ContributionsEpic.tsx',
+    input: {
+        Epic: 'src/components/modules/ContributionsEpic.tsx',
+        Banner: 'src/components/modules/Banner.tsx',
+    },
     output: {
-        file: 'dist/modules/Epic.js',
+        dir: 'dist/modules',
         format: 'es',
         sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
     },
@@ -49,7 +52,7 @@ export default {
                     },
                 ],
             ],
-            babelHelpers: 'bundled',
+            babelHelpers: 'inline',
         }),
         typescript(tsOpts),
         // eslint-disable-next-line @typescript-eslint/camelcase

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,39 +24,43 @@ const globals = {
     'emotion-theming': 'guardian.automat.emotionTheming',
 };
 
-export default {
-    input: {
-        Epic: 'src/components/modules/ContributionsEpic.tsx',
-        Banner: 'src/components/modules/Banner.tsx',
-    },
-    output: {
-        dir: 'dist/modules',
-        format: 'es',
-        sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
-    },
-    external: id => Object.keys(globals).some(key => id.startsWith(key)),
-    plugins: [
-        resolveNode(),
-        commonjs(),
-        json(),
-        babel({
-            extensions: ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'],
-            plugins: [['emotion', { sourceMap: false }]],
-            presets: [
-                [
-                    '@babel/preset-env',
-                    {
-                        targets: {
-                            ie: '11',
+const config = [
+    ['src/components/modules/ContributionsEpic.tsx', 'dist/modules/Epic.js'],
+    ['src/components/modules/Banner.tsx', 'dist/modules/Banner.js'],
+].map(([entryPoint, name]) => {
+    return {
+        input: entryPoint,
+        output: {
+            file: name,
+            format: 'es',
+            sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
+        },
+        external: id => Object.keys(globals).some(key => id.startsWith(key)),
+        plugins: [
+            resolveNode(),
+            commonjs(),
+            json(),
+            babel({
+                extensions: ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'],
+                plugins: [['emotion', { sourceMap: false }]],
+                presets: [
+                    [
+                        '@babel/preset-env',
+                        {
+                            targets: {
+                                ie: '11',
+                            },
                         },
-                    },
+                    ],
                 ],
-            ],
-            babelHelpers: 'inline',
-        }),
-        typescript(tsOpts),
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        terser({ compress: { global_defs: { 'process.env.NODE_ENV': 'production' } } }),
-        externalGlobals(globals),
-    ],
-};
+                babelHelpers: 'bundled',
+            }),
+            typescript(tsOpts),
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            terser({ compress: { global_defs: { 'process.env.NODE_ENV': 'production' } } }),
+            externalGlobals(globals),
+        ],
+    };
+});
+
+export default config;

--- a/src/components/modules/Banner.tsx
+++ b/src/components/modules/Banner.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { css } from 'emotion';
+
+const bannerStyles = css`
+    background-color: rgb(5, 41, 98);
+    color: rgb(255, 255, 255);
+    position: fixed;
+    width: 100%;
+    left: 0px;
+    bottom: -1px;
+    right: 0px;
+    z-index: 9999;
+    border-top: 1px solid;
+`;
+
+export const Banner: React.FC = ({}) => {
+    return (
+        <div className={bannerStyles}>
+            <p>This is a banner</p>
+        </div>
+    );
+};

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,3 @@
+export const isProd = process.env.NODE_ENV === 'production';
+
+export const isDev = process.env.NODE_ENV === 'development';

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -187,7 +187,7 @@ const buildBannerData = async (
     req: express.Request,
 ): Promise<{}> => {
     //TODO create return types specific to the banner
-    const moduleUrl = `${req.protocol}://${req.hostname}/banner.js`;
+    const moduleUrl = `${req.protocol}://${req.get('Host')}/banner.js`;
 
     return {
         data: {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -28,6 +28,7 @@ import { getQueryParams, Params } from './lib/params';
 import { ampDefaultEpic } from './tests/ampDefaultEpic';
 import fs from 'fs';
 import { EpicProps } from './components/modules/ContributionsEpic';
+import { isProd } from './lib/env';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -290,7 +291,8 @@ app.get(
     '/banner.js',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
-            const module = await fs.promises.readFile(__dirname + '/../dist/modules/Banner.js');
+            const path = isProd ? '/modules/Banner.js' : '/../dist/modules/Banner.js';
+            const module = await fs.promises.readFile(__dirname + path);
             res.type('js');
             res.send(module);
         } catch (error) {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -187,8 +187,6 @@ const buildBannerData = async (
     req: express.Request,
 ): Promise<{}> => {
     //TODO create return types specific to the banner
-    pageTracking && targeting && params; //TODO: remove
-
     const moduleUrl = `${req.protocol}://${req.hostname}/banner.js`;
 
     return {
@@ -264,7 +262,7 @@ app.post(
             const response = await buildBannerData(tracking, targeting, params, req);
 
             // TODO for response logging
-            res.locals.didRenderBanner = !!response.data;
+            // res.locals.didRenderBanner = !!response.data;
             // res.locals.clientName = tracking.clientName;
 
             res.send(response);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -179,6 +179,30 @@ const buildEpicData = async (
     };
 };
 
+// TODO implement this stub
+const buildBannerData = async (
+    pageTracking: EpicPageTracking,
+    targeting: EpicTargeting,
+    params: Params,
+): Promise<{}> => {
+    //TODO create return types specific to the banner
+    pageTracking && targeting && params; //TODO: remove
+
+    const moduleUrl =
+        process.env.NODE_ENV === 'production'
+            ? 'https://contributions.theguardian.com/banner.js'
+            : 'http://localhost:3040/banner.js';
+
+    return {
+        data: {
+            module: {
+                url: moduleUrl,
+                props: {},
+            },
+        },
+    };
+};
+
 // Pre-ES module endpoints (expected to be removed once module approach is validated)
 app.get(
     '/epic',
@@ -227,12 +251,50 @@ app.post(
     },
 );
 
+app.post(
+    '/banner',
+    async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        try {
+            // TODO: validate payload using an appropriate json schema
+            // if (process.env.NODE_ENV !== 'production') {
+            //     validatePayload(req.body);
+            // }
+
+            const { tracking, targeting } = req.body;
+            const params = getQueryParams(req);
+
+            const response = await buildBannerData(tracking, targeting, params);
+
+            // TODO for response logging
+            // res.locals.didRenderBanner = !!response;
+            // res.locals.clientName = tracking.clientName;
+
+            res.send(response);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
+
 // ES module endpoints
 app.get(
     '/epic.js',
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const module = await fs.promises.readFile(__dirname + '/../dist/modules/Epic.js');
+            res.type('js');
+            res.send(module);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
+
+app.get(
+    '/banner.js',
+    async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        try {
+            const module = await fs.promises.readFile(__dirname + '/../dist/modules/Banner.js');
             res.type('js');
             res.send(module);
         } catch (error) {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -184,14 +184,12 @@ const buildBannerData = async (
     pageTracking: EpicPageTracking,
     targeting: EpicTargeting,
     params: Params,
+    req: express.Request,
 ): Promise<{}> => {
     //TODO create return types specific to the banner
     pageTracking && targeting && params; //TODO: remove
 
-    const moduleUrl =
-        process.env.NODE_ENV === 'production'
-            ? 'https://contributions.theguardian.com/banner.js'
-            : 'http://localhost:3040/banner.js';
+    const moduleUrl = `${req.protocol}://${req.hostname}/banner.js`;
 
     return {
         data: {
@@ -263,10 +261,10 @@ app.post(
             const { tracking, targeting } = req.body;
             const params = getQueryParams(req);
 
-            const response = await buildBannerData(tracking, targeting, params);
+            const response = await buildBannerData(tracking, targeting, params, req);
 
             // TODO for response logging
-            // res.locals.didRenderBanner = !!response;
+            res.locals.didRenderBanner = !!response.data;
             // res.locals.clientName = tracking.clientName;
 
             res.send(response);


### PR DESCRIPTION
## What does this change?
This adds a minimal version of a banner slot implementation, so that reader revenue banners can start to be built out from here.  It is only designed to be served as a module following @nicl's spike. It cuts corners in several ways which will need to be addressed:
- The banner is a skeleton design, with no props
- Validation has been removed for banner requests
- Response logging has been removed
- Tracking has been ignored
- I have avoided (re)defining any types in detail that I didn't need to e.g. `DataResponse`

## How can we measure success?
Right now success is enabling a banner component to start being built out both in terms of component structure and logic.

## Images
![image](https://user-images.githubusercontent.com/8754692/83684860-a0a9e400-a5df-11ea-8e5d-d354460888ab.png)
