### PR TITLE
Check last banner deploy timestamp

### DIFF
--- a/src/api/contributionsApi.test.ts
+++ b/src/api/contributionsApi.test.ts
@@ -35,7 +35,11 @@ describe('fetchDefaultEpic', () => {
     it('fetches and returns the data in the expected format', async () => {
         fetchMock.get(epicUrl, epicResponse);
 
-        const [reset, fetchData] = cacheAsync(fetchDefaultEpicContent, oneDay);
+        const [reset, fetchData] = cacheAsync(
+            fetchDefaultEpicContent,
+            oneDay,
+            'fetchDefaultEpicContent',
+        );
         reset();
 
         const epicData = await fetchData();
@@ -55,7 +59,11 @@ describe('fetchDefaultEpic', () => {
     it('caches successful epic fetches', async () => {
         fetchMock.get(epicUrl, epicResponse);
 
-        const [reset, fetchData] = cacheAsync(fetchDefaultEpicContent, oneDay);
+        const [reset, fetchData] = cacheAsync(
+            fetchDefaultEpicContent,
+            oneDay,
+            'fetchDefaultEpicContent',
+        );
         reset();
 
         await fetchData();
@@ -67,7 +75,11 @@ describe('fetchDefaultEpic', () => {
     it('does not cache unsuccessful epic fetches', async () => {
         fetchMock.get(epicUrl, { status: 500 });
 
-        const [reset, fetchData] = cacheAsync(fetchDefaultEpicContent, oneDay);
+        const [reset, fetchData] = cacheAsync(
+            fetchDefaultEpicContent,
+            oneDay,
+            'fetchDefaultEpicContent',
+        );
         reset();
 
         try {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,28 +1,24 @@
 import NodeCache from 'node-cache';
 
-// Note, this is heavyweight implementation as it constructs a new cache for
-// each invocation. The assumption is that we'll only ever cache a few values;
-// if we end up wanting to cache lots of things, we should refactor to *share*
-// caches.
+const cache = new NodeCache();
+
 export const cacheAsync = <T>(
     fn: () => Promise<T>,
     ttlSec: number,
+    key: string,
 ): [() => void, () => Promise<T>] => {
-    const myCache = new NodeCache();
-    const key = 'res';
-
     const retFn = async (): Promise<T> => {
-        const got = myCache.get(key);
+        const got = cache.get(key);
         if (got !== undefined) {
             return got as T;
         }
 
         const res = await fn();
-        myCache.set(key, res, ttlSec);
+        cache.set(key, res, ttlSec);
         return res;
     };
 
-    const resetFn = (): number => myCache.del(key);
+    const resetFn = (): number => cache.del(key);
 
     return [resetFn, retFn];
 };

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -202,7 +202,7 @@ const buildBannerData = async (
     params: Params,
     req: express.Request,
 ): Promise<BannerDataResponse> => {
-    const selectedTest = selectBannerTest(targeting, pageTracking, baseUrl(req));
+    const selectedTest = await selectBannerTest(targeting, pageTracking, baseUrl(req));
 
     if (selectedTest) {
         const { test, variant, moduleUrl } = selectedTest;

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -77,7 +77,11 @@ interface MarkupResponse {
     debug?: Debug;
 }
 
-const [, fetchConfiguredEpicTestsCached] = cacheAsync(fetchConfiguredEpicTests, 60);
+const [, fetchConfiguredEpicTestsCached] = cacheAsync(
+    fetchConfiguredEpicTests,
+    60,
+    'fetchConfiguredEpicTests',
+);
 
 const asResponse = (
     component: JsComponent,

--- a/src/tests/askFourEarning.ts
+++ b/src/tests/askFourEarning.ts
@@ -13,7 +13,11 @@ import { cacheAsync } from '../lib/cache';
 import { fetchDefaultEpicContent } from '../api/contributionsApi';
 
 const fiveMinutes = 60 * 5;
-const [, fetchDefaultEpicContentCached] = cacheAsync(fetchDefaultEpicContent, fiveMinutes);
+const [, fetchDefaultEpicContentCached] = cacheAsync(
+    fetchDefaultEpicContent,
+    fiveMinutes,
+    'fetchDefaultEpicContent',
+);
 
 export const askFourEarningHardcodedTest = async (): Promise<Test> => {
     const defaultEpicVariant = await fetchDefaultEpicContentCached();

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -10,12 +10,12 @@ import { cacheAsync } from '../../lib/cache';
 type ReaderRevenueRegion = 'united-kingdom' | 'united-states' | 'australia' | 'rest-of-world';
 
 const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
-    switch (countryCode) {
-        case 'GB':
+    switch (countryCode.toLowerCase()) {
+        case 'gb':
             return 'united-kingdom';
-        case 'US':
+        case 'us':
             return 'united-states';
-        case 'AU':
+        case 'au':
             return 'australia';
         default:
             return 'rest-of-world';

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -4,24 +4,65 @@ import {
     BannerTestSelection,
 } from '../../components/BannerTypes';
 import { AusMomentContributionsBanner } from './AusMomentContributionsBannerTest';
+import fetch from 'node-fetch';
+
+type ReaderRevenueRegion = 'united-kingdom' | 'united-states' | 'australia' | 'rest-of-world';
+
+const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
+    switch (countryCode) {
+        case 'GB':
+            return 'united-kingdom';
+        case 'US':
+            return 'united-states';
+        case 'AU':
+            return 'australia';
+        default:
+            return 'rest-of-world';
+    }
+};
+
+// TODO - cache
+const fetchBannerDeployTime = (region: ReaderRevenueRegion): Promise<Date> => {
+    return fetch(`https://www.theguardian.com/reader-revenue/contributions-banner-deploy-log/${region}`)
+        .then(response => response.json())
+        .then(data => {
+            return new Date(data.time);
+        })
+};
+
+// Has the banner been redeployed since the user last closed it?
+const redeployedSinceLastClosed = (targeting: BannerTargeting): Promise<boolean> => {
+    if (targeting.engagementBannerLastClosedAt) {
+        const closedAt = targeting.engagementBannerLastClosedAt;
+        const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
+
+        return fetchBannerDeployTime(region).then(deployDate => deployDate > new Date(closedAt))
+    } else {
+        return Promise.resolve(true);
+    }
+};
 
 // TODO - implement test selection properly
 export const selectBannerTest = (
     targeting: BannerTargeting,
     pageTracking: BannerPageTracking,
     baseUrl: string,
-): BannerTestSelection | null => {
-    const tests = [AusMomentContributionsBanner];
-    const testToRun = tests.find(test => test.canRun(targeting, pageTracking));
+): Promise<BannerTestSelection | null> => {
+    return redeployedSinceLastClosed(targeting).then(hasRedeployed => {
+        if (hasRedeployed) {
+            const tests = [AusMomentContributionsBanner];
+            const testToRun = tests.find(test => test.canRun(targeting, pageTracking));
 
-    if (testToRun) {
-        const variant = testToRun.variants[0]; // TODO - use mvt
-        return {
-            test: testToRun,
-            variant,
-            moduleUrl: `${baseUrl}/${variant.modulePath}`,
-        };
-    } else {
+            if (testToRun) {
+                const variant = testToRun.variants[0]; // TODO - use mvt
+                return {
+                    test: testToRun,
+                    variant,
+                    moduleUrl: `${baseUrl}/${variant.modulePath}`,
+                };
+            }
+        }
+
         return null;
-    }
+    });
 };


### PR DESCRIPTION
Checks the `engagementBannerLastClosedAt` supplied by the client and compares it against the last deploy timestamp of the banner.
The deploy timestamps are cached per region.

TODO - this stuff really needs tests