### PR TITLE
Tp aus moment contribs banner

### DIFF
--- a/src/components/AusMomentContributionsBanner.stories.tsx
+++ b/src/components/AusMomentContributionsBanner.stories.tsx
@@ -39,7 +39,7 @@ const tickerSettings = {
 
 export const defaultStory = (): ReactElement => {
     const isSupporter = boolean('isSupporter', false);
-    const total = number('total', 140_000);
+    const total = number('total', 120_000);
 
     tickerSettings.tickerData.total = total;
 

--- a/src/components/AusMomentContributionsBanner.stories.tsx
+++ b/src/components/AusMomentContributionsBanner.stories.tsx
@@ -47,7 +47,7 @@ export const defaultStory = (): ReactElement => {
         <StorybookWrapper>
             <AusMomentContributionsBanner
                 isSupporter={isSupporter}
-                tickerSettings={tickerSettings}
+                tickerSettings={{ ...tickerSettings }}
                 tracking={tracking}
             />
         </StorybookWrapper>

--- a/src/components/AusMomentContributionsBanner.stories.tsx
+++ b/src/components/AusMomentContributionsBanner.stories.tsx
@@ -39,7 +39,7 @@ const tickerSettings = {
 
 export const defaultStory = (): ReactElement => {
     const isSupporter = boolean('isSupporter', false);
-    const total = number('total', 120_000);
+    const total = number('total', 140_000);
 
     tickerSettings.tickerData.total = total;
 

--- a/src/components/AusMomentContributionsBanner.stories.tsx
+++ b/src/components/AusMomentContributionsBanner.stories.tsx
@@ -39,7 +39,7 @@ const tickerSettings = {
 
 export const defaultStory = (): ReactElement => {
     const isSupporter = boolean('isSupporter', false);
-    const total = number('total', 120_000);
+    const total = number('total', 140_000);
 
     tickerSettings.tickerData.total = total;
 
@@ -47,7 +47,7 @@ export const defaultStory = (): ReactElement => {
         <StorybookWrapper>
             <AusMomentContributionsBanner
                 isSupporter={isSupporter}
-                tickerSettings={{ ...tickerSettings }}
+                tickerSettings={tickerSettings}
                 tracking={tracking}
             />
         </StorybookWrapper>

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -471,14 +471,23 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
     const totalSupporters = tickerSettings.tickerData.total;
     const supportersGoal = tickerSettings.tickerData.goal;
 
-    const animateSunrise = (): void => {
-        const increment = 15;
-        supporters + increment < totalSupporters
-            ? setSupporters(supporters + increment)
-            : setSupporters(totalSupporters);
-    };
+    useEffect(() => {
+        if (supporters) {
+            const increment = 250;
+            const interval = setInterval(() => {
+                supporters + increment < totalSupporters
+                    ? setSupporters(supporters + increment)
+                    : setSupporters(totalSupporters);
+            }, 20);
 
-    useEffect(animateSunrise);
+            return (): void => {
+                clearInterval(interval);
+            };
+        }
+        return (): void => {
+            null;
+        };
+    }, [supporters, totalSupporters]);
 
     return (
         <>

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -653,7 +653,7 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
     const supportersGoal = tickerSettings.tickerData.goal;
 
     const animationDurationInMS = 2000;
-    const [animationStartTime, _] = useState(Date.now());
+    const [animationStartTime, ,] = useState(Date.now());
 
     const getSupportersForAnimation = (): number => {
         const elapsedTimeInMS = Math.min(Date.now() - animationStartTime, animationDurationInMS);

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -100,14 +100,31 @@ const EnvelopeSvg: React.FC = () => {
 
 const banner = (supporters: number): string => css`
     width: 100%;
-    max-width: 1440px;
     margin: 0;
     padding: 0;
     position: relative;
     height: 420px !important;
     box-sizing: border-box;
     display: flex;
-    background: ${sunBackground(supporters)};
+    // background: ${sunBackground(supporters)};
+`;
+
+// TODO: better way to fill screen? (view box?)
+const sunSVG = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 230px;
+    background-color: ${opinion[500]};
+`;
+
+const innnerCircle = css`
+    color: ${brandAlt[400]};
+`;
+
+const outerCircle = css`
+    color: ${brandAlt[200]};
 `;
 
 const closeButton = css`
@@ -247,6 +264,7 @@ const svgAndBottomContentContainer = css`
     display: flex;
     align-items: stretch;
     flex-direction: column;
+    margin-top: -20px;
 `;
 
 const horizonContainer = css`
@@ -493,6 +511,22 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section className={banner(supporters)}>
+                    <svg className={sunSVG}>
+                        <circle
+                            className={outerCircle}
+                            cx="50%"
+                            cy="75%"
+                            r="40%"
+                            fill="currentColor"
+                        />
+                        <circle
+                            className={innnerCircle}
+                            cx="50%"
+                            cy="75%"
+                            r="15%"
+                            fill="currentColor"
+                        />
+                    </svg>
                     <div className={contentContainer}>
                         <div className={topContentContainer}>
                             <div className={actualNumber}>

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -15,29 +15,10 @@ import { setContributionsBannerClosedTimestamp } from './localStorage';
 
 const targetIncrease = 30_000;
 const startingAmt = 120_000;
-const haloSize = 65;
-const startPercent = 20;
 
 const calculatePercentage = (supporters: number): number => {
     const startToCurrentDiff = Math.min(Math.max(supporters - startingAmt, 0), targetIncrease);
     return startToCurrentDiff / targetIncrease;
-};
-
-const calculateCircumference = (supporters: number): number => {
-    const startToCurrentDiff = Math.min(Math.max(supporters - startingAmt, 0), targetIncrease);
-    const percentageGained = startToCurrentDiff / targetIncrease;
-    return startPercent * (1 - percentageGained) + percentageGained * haloSize;
-};
-
-const sunBackground = (supporters: number): string => {
-    const circumference = calculateCircumference(supporters);
-    return `radial-gradient(
-        circle at center,
-        ${brandAlt[400]} ${circumference}%,
-        ${brandAlt[200]} ${circumference}%,
-        ${brandAlt[200]} ${haloSize}%,
-        ${opinion[500]} ${haloSize}%
-    ) !important`;
 };
 
 const FacebookLogoSvg: React.FC = () => {
@@ -103,7 +84,7 @@ const EnvelopeSvg: React.FC = () => {
     );
 };
 
-const banner = (supporters: number): string => css`
+const banner = css`
     width: 100%;
     margin: 0;
     padding: 0;
@@ -112,7 +93,6 @@ const banner = (supporters: number): string => css`
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    // background: ${sunBackground(supporters)};
 `;
 
 const sunSVGContainer = css`
@@ -675,7 +655,7 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
     return (
         <>
             {showBanner ? (
-                <section className={banner(supporters)}>
+                <section className={banner}>
                     <div className={sunSVGContainer}>
                         <svg className={sunSVG} viewBox="0 0 1300 230">
                             {/* wide */}

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -516,22 +516,22 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
     const totalSupporters = tickerSettings.tickerData.total;
     const supportersGoal = tickerSettings.tickerData.goal;
 
-    useEffect(() => {
-        if (supporters) {
-            const increment = 250;
-            const interval = setInterval(() => {
-                supporters + increment < totalSupporters
-                    ? setSupporters(supporters + increment)
-                    : setSupporters(totalSupporters);
-            }, 20);
+    const animationDurationInMS = 2000;
+    const [animationStartTime, _] = useState(Date.now());
 
-            return (): void => {
-                clearInterval(interval);
-            };
+    const getSupportersForAnimation = (): number => {
+        const elapsedTimeInMS = Math.min(Date.now() - animationStartTime, animationDurationInMS);
+        const percentageCompleted = elapsedTimeInMS / animationDurationInMS;
+
+        return startingAmt * (1 - percentageCompleted) + totalSupporters * percentageCompleted;
+    };
+
+    useEffect(() => {
+        if (supporters < totalSupporters) {
+            window.requestAnimationFrame(() => {
+                setSupporters(getSupportersForAnimation());
+            });
         }
-        return (): void => {
-            null;
-        };
     }, [supporters, totalSupporters]);
 
     const percentage = calculatePercentage(totalSupporters);

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -124,34 +124,169 @@ const sunSVG = css`
     background-color: ${opinion[500]};
 `;
 
-function getInnerCircleFill(percentage: number): number {
-    const startingFill = 15;
-    const finalFill = 50;
-
-    return startingFill * (1 - percentage) + finalFill * percentage;
+function getInnerCircleFill(start: number, stop: number, percentage: number): number {
+    return start * (1 - percentage) + stop * percentage;
 }
 
-const innnerCircle = (percentage: number): string => {
+const innnerCircleMobile = (percentage: number): string => {
+    const start = 30;
+    const stop = 50;
+    const fill = getInnerCircleFill(start, stop, percentage);
     return css`
-        clip-path: circle(${getInnerCircleFill(percentage)}%);
-        @keyframes grow {
+        clip-path: circle(${fill}%);
+        @keyframes grow-mobile {
             0% {
-                clip-path: circle(15%);
+                clip-path: circle(${start}%);
             }
             100% {
-                clip-path: circle(${getInnerCircleFill(percentage)}%);
+                clip-path: circle(${fill}%);
             }
         }
         color: ${brandAlt[400]};
-        animation-name: grow;
+        animation-name: grow-mobile;
         animation-duration: 2s;
         animation-timing-function: ease;
         animation-iteration-count: 1;
+
+        ${from.tablet} {
+            display: none;
+        }
     `;
 };
 
-const outerCircle = css`
+const innnerCircleTablet = (percentage: number): string => {
+    const start = 20;
+    const stop = 50;
+    const fill = getInnerCircleFill(start, stop, percentage);
+    return css`
+        clip-path: circle(${fill}%);
+        @keyframes grow-tablet {
+            0% {
+                clip-path: circle(${start}%);
+            }
+            100% {
+                clip-path: circle(${fill}%);
+            }
+        }
+        color: ${brandAlt[400]};
+        animation-name: grow-tablet;
+        animation-duration: 2s;
+        animation-timing-function: ease;
+        animation-iteration-count: 1;
+
+        display: none;
+
+        ${from.tablet} {
+            display: block;
+        }
+
+        ${from.desktop} {
+            display: none;
+        }
+    `;
+};
+
+const innnerCircleDesktop = (percentage: number): string => {
+    const start = 18;
+    const stop = 50;
+    const fill = getInnerCircleFill(start, stop, percentage);
+    return css`
+        clip-path: circle(${fill}%);
+        @keyframes grow-desktop {
+            0% {
+                clip-path: circle(${start}%);
+            }
+            100% {
+                clip-path: circle(${fill}%);
+            }
+        }
+        color: ${brandAlt[400]};
+        animation-name: grow-desktop;
+        animation-duration: 2s;
+        animation-timing-function: ease;
+        animation-iteration-count: 1;
+
+        display: none;
+
+        ${from.desktop} {
+            display: block;
+        }
+
+        ${from.wide} {
+            display: none;
+        }
+    `;
+};
+
+const innnerCircleWide = (percentage: number): string => {
+    const start = 18;
+    const stop = 50;
+    const fill = getInnerCircleFill(start, stop, percentage);
+    return css`
+        clip-path: circle(${fill}%);
+        @keyframes grow-desktop {
+            0% {
+                clip-path: circle(${start}%);
+            }
+            100% {
+                clip-path: circle(${fill}%);
+            }
+        }
+        color: ${brandAlt[400]};
+        animation-name: grow-desktop;
+        animation-duration: 2s;
+        animation-timing-function: ease;
+        animation-iteration-count: 1;
+
+        display: none;
+
+        ${from.desktop} {
+            display: block;
+        }
+    `;
+};
+
+const outerCircleMobile = css`
     color: ${brandAlt[200]};
+
+    ${from.tablet} {
+        display: none;
+    }
+`;
+
+const outerCircleTablet = css`
+    color: ${brandAlt[200]};
+    display: none;
+
+    ${from.tablet} {
+        display: block;
+    }
+
+    ${from.desktop} {
+        display: none;
+    }
+`;
+
+const outerCircleDesktop = css`
+    color: ${brandAlt[200]};
+    display: none;
+
+    ${from.desktop} {
+        display: block;
+    }
+
+    ${from.wide} {
+        display: none;
+    }
+`;
+
+const outerCircleWide = css`
+    color: ${brandAlt[200]};
+    display: none;
+
+    ${from.wide} {
+        display: block;
+    }
 `;
 
 const closeButton = css`
@@ -540,19 +675,65 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section className={banner(supporters)}>
-                    <svg className={sunSVG}>
+                    <svg className={sunSVG} viewBox="0 0 1300 230">
+                        {/* wide */}
                         <circle
-                            className={outerCircle}
+                            className={outerCircleWide}
                             cx="50%"
-                            cy="75%"
-                            r="40%"
+                            cy="90%"
+                            r="45%"
                             fill="currentColor"
                         />
                         <circle
-                            className={innnerCircle(percentage)}
+                            className={innnerCircleWide(percentage)}
                             cx="50%"
-                            cy="75%"
-                            r="40%"
+                            cy="90%"
+                            r="45%"
+                            fill="currentColor"
+                        />
+                        {/* desktop */}
+                        <circle
+                            className={outerCircleDesktop}
+                            cx="50%"
+                            cy="90%"
+                            r="55%"
+                            fill="currentColor"
+                        />
+                        <circle
+                            className={innnerCircleDesktop(percentage)}
+                            cx="50%"
+                            cy="90%"
+                            r="55%"
+                            fill="currentColor"
+                        />
+                        {/* tablet */}
+                        <circle
+                            className={outerCircleTablet}
+                            cx="50%"
+                            cy="120%"
+                            r="55%"
+                            fill="currentColor"
+                        />
+                        <circle
+                            className={innnerCircleTablet(percentage)}
+                            cx="50%"
+                            cy="120%"
+                            r="55%"
+                            fill="currentColor"
+                        />
+                        {/* mobile */}
+                        <circle
+                            className={outerCircleMobile}
+                            cx="50%"
+                            cy="250%"
+                            r="65%"
+                            fill="currentColor"
+                        />
+                        <circle
+                            className={innnerCircleMobile(percentage)}
+                            cx="50%"
+                            cy="250%"
+                            r="65%"
                             fill="currentColor"
                         />
                     </svg>

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -225,7 +225,7 @@ const innnerCircleWide = (percentage: number): string => {
     const fill = getInnerCircleFill(start, stop, percentage);
     return css`
         clip-path: circle(${fill}%);
-        @keyframes grow-desktop {
+        @keyframes grow-wide {
             0% {
                 clip-path: circle(${start}%);
             }
@@ -234,7 +234,7 @@ const innnerCircleWide = (percentage: number): string => {
             }
         }
         color: ${brandAlt[400]};
-        animation-name: grow-desktop;
+        animation-name: grow-wide;
         animation-duration: 2s;
         animation-timing-function: ease;
         animation-iteration-count: 1;

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -111,14 +111,15 @@ const banner = (supporters: number): string => css`
     height: 420px !important;
     box-sizing: border-box;
     display: flex;
+    flex-direction: column;
     // background: ${sunBackground(supporters)};
 `;
 
-// TODO: better way to fill screen? (view box?)
-const sunSVG = css`
+const sunSVGContainer = css`
     position: fixed;
-    top: 0;
-    left: 0;
+`;
+
+const sunSVG = css`
     width: 100%;
     height: 230px;
     background-color: ${opinion[500]};
@@ -675,68 +676,70 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section className={banner(supporters)}>
-                    <svg className={sunSVG} viewBox="0 0 1300 230">
-                        {/* wide */}
-                        <circle
-                            className={outerCircleWide}
-                            cx="50%"
-                            cy="90%"
-                            r="45%"
-                            fill="currentColor"
-                        />
-                        <circle
-                            className={innnerCircleWide(percentage)}
-                            cx="50%"
-                            cy="90%"
-                            r="45%"
-                            fill="currentColor"
-                        />
-                        {/* desktop */}
-                        <circle
-                            className={outerCircleDesktop}
-                            cx="50%"
-                            cy="90%"
-                            r="55%"
-                            fill="currentColor"
-                        />
-                        <circle
-                            className={innnerCircleDesktop(percentage)}
-                            cx="50%"
-                            cy="90%"
-                            r="55%"
-                            fill="currentColor"
-                        />
-                        {/* tablet */}
-                        <circle
-                            className={outerCircleTablet}
-                            cx="50%"
-                            cy="120%"
-                            r="55%"
-                            fill="currentColor"
-                        />
-                        <circle
-                            className={innnerCircleTablet(percentage)}
-                            cx="50%"
-                            cy="120%"
-                            r="55%"
-                            fill="currentColor"
-                        />
-                        {/* mobile */}
-                        <circle
-                            className={outerCircleMobile}
-                            cx="50%"
-                            cy="250%"
-                            r="65%"
-                            fill="currentColor"
-                        />
-                        <circle
-                            className={innnerCircleMobile(percentage)}
-                            cx="50%"
-                            cy="250%"
-                            r="65%"
-                            fill="currentColor"
-                        />
-                    </svg>
+                    <div className={sunSVGContainer}>
+                        <svg className={sunSVG} viewBox="0 0 1300 230">
+                            {/* wide */}
+                            <circle
+                                className={outerCircleWide}
+                                cx="50%"
+                                cy="90%"
+                                r="45%"
+                                fill="currentColor"
+                            />
+                            <circle
+                                className={innnerCircleWide(percentage)}
+                                cx="50%"
+                                cy="90%"
+                                r="45%"
+                                fill="currentColor"
+                            />
+                            {/* desktop */}
+                            <circle
+                                className={outerCircleDesktop}
+                                cx="50%"
+                                cy="90%"
+                                r="55%"
+                                fill="currentColor"
+                            />
+                            <circle
+                                className={innnerCircleDesktop(percentage)}
+                                cx="50%"
+                                cy="90%"
+                                r="55%"
+                                fill="currentColor"
+                            />
+                            {/* tablet */}
+                            <circle
+                                className={outerCircleTablet}
+                                cx="50%"
+                                cy="120%"
+                                r="55%"
+                                fill="currentColor"
+                            />
+                            <circle
+                                className={innnerCircleTablet(percentage)}
+                                cx="50%"
+                                cy="120%"
+                                r="55%"
+                                fill="currentColor"
+                            />
+                            {/* mobile */}
+                            <circle
+                                className={outerCircleMobile}
+                                cx="50%"
+                                cy="250%"
+                                r="65%"
+                                fill="currentColor"
+                            />
+                            <circle
+                                className={innnerCircleMobile(percentage)}
+                                cx="50%"
+                                cy="250%"
+                                r="65%"
+                                fill="currentColor"
+                            />
+                        </svg>
+                    </div>
                     <div className={contentContainer}>
                         <div className={topContentContainer}>
                             <div className={actualNumber}>

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -18,6 +18,11 @@ const startingAmt = 120_000;
 const haloSize = 65;
 const startPercent = 20;
 
+const calculatePercentage = (supporters: number): number => {
+    const startToCurrentDiff = Math.min(Math.max(supporters - startingAmt, 0), targetIncrease);
+    return startToCurrentDiff / targetIncrease;
+};
+
 const calculateCircumference = (supporters: number): number => {
     const startToCurrentDiff = Math.min(Math.max(supporters - startingAmt, 0), targetIncrease);
     const percentageGained = startToCurrentDiff / targetIncrease;
@@ -119,9 +124,31 @@ const sunSVG = css`
     background-color: ${opinion[500]};
 `;
 
-const innnerCircle = css`
-    color: ${brandAlt[400]};
-`;
+function getInnerCircleFill(percentage: number): number {
+    const startingFill = 15;
+    const finalFill = 50;
+
+    return startingFill * (1 - percentage) + finalFill * percentage;
+}
+
+const innnerCircle = (percentage: number): string => {
+    return css`
+        clip-path: circle(${getInnerCircleFill(percentage)}%);
+        @keyframes grow {
+            0% {
+                clip-path: circle(15%);
+            }
+            100% {
+                clip-path: circle(${getInnerCircleFill(percentage)}%);
+            }
+        }
+        color: ${brandAlt[400]};
+        animation-name: grow;
+        animation-duration: 2s;
+        animation-timing-function: ease;
+        animation-iteration-count: 1;
+    `;
+};
 
 const outerCircle = css`
     color: ${brandAlt[200]};
@@ -507,6 +534,8 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
         };
     }, [supporters, totalSupporters]);
 
+    const percentage = calculatePercentage(totalSupporters);
+
     return (
         <>
             {showBanner ? (
@@ -520,10 +549,10 @@ export const AusMomentContributionsBanner: React.FC<BannerProps> = ({
                             fill="currentColor"
                         />
                         <circle
-                            className={innnerCircle}
+                            className={innnerCircle(percentage)}
                             cx="50%"
                             cy="75%"
-                            r="15%"
+                            r="40%"
                             fill="currentColor"
                         />
                     </svg>


### PR DESCRIPTION
## What does this change?
Alter the way the animation was implemented. Before we were using a radial gradient and animating it through js, now we use an svg and animate the clip-path property to achieve the growing effect. Had to duplicate quite a lot of css as we're not using emotion in a way that allows for composition. 

## How can we measure success?

## Images

Had to tweak the svg across the four different breakpoints in the design. As this required changing svg attributes and not css properties this had to be done by hiding/showing svg elements based on the viewport size.

mobile: 
<img width="368" alt="Screenshot 2020-06-23 at 09 13 22" src="https://user-images.githubusercontent.com/17720442/85378586-a8034400-b532-11ea-9b31-ffeb6710ce5a.png">

tablet:
<img width="865" alt="Screenshot 2020-06-23 at 09 13 39" src="https://user-images.githubusercontent.com/17720442/85378596-ac2f6180-b532-11ea-8d6c-992ba6a2c0e0.png">

desktop: 
<img width="1146" alt="Screenshot 2020-06-23 at 09 14 00" src="https://user-images.githubusercontent.com/17720442/85378615-afc2e880-b532-11ea-9d73-1dbb8feb4d85.png">

wide: 
<img width="1391" alt="Screenshot 2020-06-23 at 09 13 05" src="https://user-images.githubusercontent.com/17720442/85378624-b2bdd900-b532-11ea-8f4d-484b687e4420.png">
