### PR TITLE
Make isPaidContent optional

### DIFF
--- a/src/components/BannerTypes.ts
+++ b/src/components/BannerTypes.ts
@@ -5,7 +5,7 @@ import { TickerSettings } from '../lib/variants';
 export type BannerTargeting = {
     alreadyVisitedCount: number;
     shouldHideReaderRevenue?: boolean;
-    isPaidContent: boolean;
+    isPaidContent?: boolean;
     showSupportMessaging: boolean;
     engagementBannerLastClosedAt?: string;
     mvtId: number;

--- a/src/schemas/bannerPayload.schema.json
+++ b/src/schemas/bannerPayload.schema.json
@@ -55,7 +55,6 @@
             },
             "required": [
                 "alreadyVisitedCount",
-                "isPaidContent",
                 "showSupportMessaging"
             ]
         }

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -83,6 +83,7 @@ export const selectBannerTest = (
                 test =>
                     targeting.alreadyVisitedCount >= test.minPageViews &&
                     !targeting.shouldHideReaderRevenue &&
+                    !targeting.isPaidContent &&
                     test.canRun(targeting, pageTracking),
             );
 


### PR DESCRIPTION
A number of requests to the banner data endpoint are missing the `isPaidContent` field. Presumably it's `undefined` on the client. It's not clear why some pages do not have this field at all.
We're currently rejecting over 2000 requests an hour with 400s because the field is missing.

Also, the bannerSelection logic wasn't even using this field!