### PR TITLE
Tp aus moment banner bug fixes

### DIFF
--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -291,6 +291,7 @@ const mobileMessage = (isExpanded: boolean = false): string => {
 
 const ctaContainer = css`
     display: flex;
+    align-items: center;
     padding: 0;
     margin: 0;
     max-height: 40px;
@@ -357,11 +358,14 @@ const shareYourSupport = css`
     margin-left: ${space[4]}px;
     color: ${neutral[86]};
     ${textSans.medium()};
+    font-size: 15px;
     ${from.tablet} {
-        margin: 0;
+        margin-left: 0;
+        margin-top: ${space[1]}px;
     }
     ${from.desktop} {
-        margin-left: ${space[4]}px;
+        margin: auto 0 auto ${space[4]}px;
+        font-size: 17px;
     }
 `;
 

--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -7,7 +7,7 @@ import { space } from '@guardian/src-foundations';
 import { BannerProps } from '../Banner';
 import { setContributionsBannerClosedTimestamp } from './localStorage';
 import { BannerTracking } from '../../BannerTypes';
-import { SocialLinks } from './social-links';
+import SocialLinks from './SocialLinks';
 import { SvgClose } from '@guardian/src-icons';
 import SunriseBackground from './SunriseBackground';
 import { useWindowSize } from './useWindowSize';

--- a/src/components/modules/contributionsBanners/SocialLinks.tsx
+++ b/src/components/modules/contributionsBanners/SocialLinks.tsx
@@ -1,4 +1,3 @@
-// @flow
 import React from 'react';
 import { css } from 'emotion';
 import { neutral, opinion } from '@guardian/src-foundations/palette';
@@ -32,7 +31,7 @@ const socialLinkSvg = css`
     }
 `;
 
-export const SocialLinks = (): JSX.Element => (
+const SocialLinks = (): JSX.Element => (
     <div className={socialLinksWrapper}>
         <a href={links.facebook} className={socialLink} target="_blank" rel="noopener noreferrer">
             <svg
@@ -96,3 +95,5 @@ export const SocialLinks = (): JSX.Element => (
         </a>
     </div>
 );
+
+export default SocialLinks;

--- a/src/components/modules/contributionsBanners/social-links.tsx
+++ b/src/components/modules/contributionsBanners/social-links.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { neutral, opinion } from '@guardian/src-foundations/palette';
+import { space } from '@guardian/src-foundations';
 
 const links = {
     facebook:
@@ -12,16 +13,19 @@ const links = {
         'mailto:?subject=Guardian%20Australia%20supporters%20are%20doing%20something%20powerful&body=Guardian%20Australia%20supporters%20are%20doing%20something%20powerful%0AI%20support%20the%20Guardian%20because%20I%20believe%20their%20independent%20journalism%20is%20vital%2C%20and%20should%20be%20open%20and%20free%20to%20all.%20Join%20me.%20With%20your%20support%2C%20we%20can%20do%20more.%20%23supporttheguardian%0A%0Ahttps%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_email',
 };
 
-const linksWrapper = css`
-    margin: 0 -3px;
+const socialLinksWrapper = css`
+    display: flex;
+    margin-left: -${space[2]}px;
     padding-bottom: -10px;
 `;
 
 const socialLink = css`
-    margin: 0 3px;
+    margin-left: ${space[2]}px;
 `;
 
-const socialLinkButton = css`
+const socialLinkSvg = css`
+    display: block;
+
     fill: ${opinion[400]};
     &:hover {
         fill: ${opinion[300]};
@@ -29,16 +33,17 @@ const socialLinkButton = css`
 `;
 
 export const SocialLinks = (): JSX.Element => (
-    <div className={linksWrapper}>
+    <div className={socialLinksWrapper}>
         <a href={links.facebook} className={socialLink} target="_blank" rel="noopener noreferrer">
             <svg
+                className={socialLinkSvg}
                 width="36"
                 height="36"
                 viewBox="0 0 36 36"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
             >
-                <circle cx="18" cy="18" r="18" className={socialLinkButton} />
+                <circle cx="18" cy="18" r="18" />
                 <path
                     fillRule="evenodd"
                     clipRule="evenodd"
@@ -50,13 +55,14 @@ export const SocialLinks = (): JSX.Element => (
 
         <a href={links.twitter} className={socialLink} target="_blank" rel="noopener noreferrer">
             <svg
+                className={socialLinkSvg}
                 width="36"
                 height="36"
                 viewBox="0 0 36 36"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
             >
-                <circle cx="18" cy="18" r="18" className={socialLinkButton} />
+                <circle cx="18" cy="18" r="18" />
                 <path
                     fillRule="evenodd"
                     clipRule="evenodd"
@@ -68,13 +74,14 @@ export const SocialLinks = (): JSX.Element => (
 
         <a href={links.email} className={socialLink} target="_blank" rel="noopener noreferrer">
             <svg
+                className={socialLinkSvg}
                 width="36"
                 height="36"
                 viewBox="0 0 36 36"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
             >
-                <circle cx="18" cy="18" r="18" className={socialLinkButton} />
+                <circle cx="18" cy="18" r="18" />
                 <path
                     d="M25.632 13.4248L18.8533 18.8236H17.6174L10.8387 13.4248L11.5582 12.6471H24.9125L25.632 13.4248Z"
                     fill="#F6F6F6"


### PR DESCRIPTION
## What does this change?

Fix the subscriber cta layout issues on mobile. This involved making the svgs display block to remove space that the browser was adding below them. Additionally, the copy is now changed to 15px on mobile. Also did a tiny refactor to tidy up the social links component file.

## How can we measure success?

## Images

<img width="295" alt="Screenshot 2020-06-26 at 10 42 22" src="https://user-images.githubusercontent.com/17720442/85844099-1990fb80-b79a-11ea-8fbe-ca2e6b26a677.png">

