### PR TITLE
Tp aus moment banner nice to haves

### DIFF
--- a/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
+++ b/src/components/modules/contributionsBanners/AusMomentContributionsBanner.tsx
@@ -319,6 +319,7 @@ const readMore = css`
     cursor: pointer;
     color: ${neutral[86]};
     ${body.medium()};
+    font-size: 15px;
     border-bottom: 1px solid ${neutral[86]};
 `;
 

--- a/src/components/modules/contributionsBanners/SunriseBackground.tsx
+++ b/src/components/modules/contributionsBanners/SunriseBackground.tsx
@@ -219,7 +219,7 @@ const SunriseBackground: React.FC<SunriseBackgroundProps> = ({
                         <circle
                             className={outerCircleWide}
                             cx="50%"
-                            cy="90%"
+                            cy="50%"
                             r="45%"
                             fill="currentColor"
                         />
@@ -250,7 +250,7 @@ const SunriseBackground: React.FC<SunriseBackgroundProps> = ({
                     <circle
                         className={innerCircleWide(percentage)}
                         cx="50%"
-                        cy="90%"
+                        cy="50%"
                         r="45%"
                         fill="currentColor"
                     />


### PR DESCRIPTION
## What does this change?

Implement two of the nice to haves for the banner:
- make the read more button 15px
- fix the position of the sun at the wide breakpoint

## Images
<img width="1291" alt="Screenshot 2020-06-29 at 10 07 38" src="https://user-images.githubusercontent.com/17720442/85996102-5eff3400-b9f9-11ea-8c42-4fae40af9d35.png">
