### PR TITLE
Fix incorrect placeholder name

### DIFF
--- a/src/components/ContributionsEpic.tsx
+++ b/src/components/ContributionsEpic.tsx
@@ -27,7 +27,7 @@ const replacePlaceholders = (
     // Replace country code placeholder with actual country name
     // Should only replace if we were able to determine the country name from country code
     const countryName = getCountryName(countryCode) ?? '';
-    content = countryName ? content.replace(/%%COUNTRY_CODE%%/g, countryName) : content;
+    content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;
 
     return content;
 };

--- a/src/components/modules/ContributionsEpic.tsx
+++ b/src/components/modules/ContributionsEpic.tsx
@@ -26,7 +26,7 @@ const replacePlaceholders = (
     // Replace country code placeholder with actual country name
     // Should only replace if we were able to determine the country name from country code
     const countryName = getCountryName(countryCode) ?? '';
-    content = countryName ? content.replace(/%%COUNTRY_CODE%%/g, countryName) : content;
+    content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;
 
     return content;
 };


### PR DESCRIPTION
## What does this change?

Updates the `%%COUNTRY_NAME%%` placeholder to match frontend. When this functionality was added to the contributions service it looks like we used the wrong name.

## How can we measure success?

This change ensures we correctly replace the country name placeholder. We should follow up and add a final check which ensures there are no unreplaced placeholders in the final output.

## Images
