### PR TITLE
Check for invalid placeholders

### DIFF
--- a/src/lib/placeholders.test.ts
+++ b/src/lib/placeholders.test.ts
@@ -1,0 +1,23 @@
+import { containsPlaceholder, containsUnexpectedPlaceholder } from './placeholders';
+
+describe('shouldNotRenderEpic', () => {
+    it('returns true if string contains placeholder', () => {
+        const got = containsPlaceholder('apple %%SOME_PLACEHOLDER%%');
+        expect(got).toBe(true);
+    });
+
+    it('returns false if string does not contain placeholder', () => {
+        const got = containsPlaceholder('apple without placeholder');
+        expect(got).toBe(false);
+    });
+
+    it('return true if string contains unexpected placeholder', () => {
+        const got = containsUnexpectedPlaceholder('apple %%UNEXPECTED%%', ['%%EXPECTED%%']);
+        expect(got).toBe(true);
+    });
+
+    it('returns false if string does not contain unexpected placeholder', () => {
+        const got = containsUnexpectedPlaceholder('apple %%EXPECTED%%', ['%%EXPECTED%%']);
+        expect(got).toBe(false);
+    });
+});

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,0 +1,36 @@
+import { getCountryName, getLocalCurrencySymbol } from './geolocation';
+
+const expectedPlaceholders = ['%%CURRENCY_SYMBOL%%', '%%ARTICLE_COUNT%%', '%%COUNTRY_NAME%%'];
+
+export const replacePlaceholders = (
+    content: string | undefined,
+    numArticles: number,
+    countryCode?: string,
+): string => {
+    if (!content) {
+        return '';
+    }
+
+    content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
+    content = content.replace(/%%ARTICLE_COUNT%%/g, numArticles.toString());
+
+    const countryName = getCountryName(countryCode) ?? '';
+    content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;
+
+    return content;
+};
+
+export const containsPlaceholder = (text: string): boolean => text.includes('%%');
+
+export const containsUnexpectedPlaceholder = (
+    text: string,
+    placeholders: string[] = expectedPlaceholders,
+): boolean => {
+    const matches = text.match(/%%.*%%/);
+
+    if (!matches) {
+        return false;
+    }
+
+    return matches.some(match => !placeholders.includes(match));
+};

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -14,6 +14,7 @@ import {
     userInTest,
     hasNoZeroArticleCount,
     isNotExpired,
+    hasNoUnexpectedPlaceholders,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -738,6 +739,26 @@ describe('isNotExpired filter', () => {
         const filter = isNotExpired(now);
 
         const got = filter.test(test, targetingDefault);
+
+        expect(got).toBe(false);
+    });
+});
+
+describe('hasNoUnexpectedPlaceholders filter', () => {
+    it('should pass if present placeholders are expected', () => {
+        const variant = testDefault.variants[0];
+        variant.heading = 'With expected placeholder &&CURRENCY_SYMBOL%%';
+        const test: Test = { ...testDefault, variants: [variant] };
+        const got = excludeSection.test(test, targetingDefault);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail if unexpected placeholders found', () => {
+        const variant = testDefault.variants[0];
+        variant.heading = 'With unexpected placeholder %%UNKNOWN%%';
+        const test: Test = { ...testDefault, variants: [variant] };
+        const got = hasNoUnexpectedPlaceholders.test(test, targetingDefault);
 
         expect(got).toBe(false);
     });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -8,6 +8,7 @@ import { shouldThrottle, shouldNotRenderEpic } from '../lib/targeting';
 import { getArticleViewCountForWeeks } from '../lib/history';
 import { getCountryName, countryCodeToCountryGroupId } from '../lib/geolocation';
 import { isRecentOneOffContributor } from '../lib/dates';
+import { containsUnexpectedPlaceholder } from './placeholders';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -308,6 +309,19 @@ export const hasNoZeroArticleCount = (now: Date = new Date(), templateWeeks = 52
     },
 });
 
+export const hasNoUnexpectedPlaceholders: Filter = {
+    id: 'hasNoUnexpectedPlaceholders',
+    test: (test): boolean => {
+        const headings = test.variants.map(v => v.heading || '');
+        const highlighted = test.variants.map(v => v.highlightedText || '');
+        const paras = test.variants.map(v => v.paragraphs.join());
+
+        return ![...headings, ...highlighted, ...paras].some(str =>
+            containsUnexpectedPlaceholder(str),
+        );
+    },
+};
+
 export const shouldNotRender: Filter = {
     id: 'shouldNotRender',
     test: (_, targeting) => !shouldNotRenderEpic(targeting),
@@ -365,6 +379,7 @@ export const findTestAndVariant = (
         noArticleViewedSettings,
         isContentType,
         hasNoZeroArticleCount(),
+        hasNoUnexpectedPlaceholders,
     ];
 
     const priorityOrdered = ([] as Test[]).concat(


### PR DESCRIPTION
See https://github.com/guardian/contributions-service/pull/173 for context.

## What does this change?

Tests with unsupported placeholders are ignored to ensure we don't serve any with unsupported placeholders.

As part of this, some of the placeholder logic has been refactored out into a separate lib file.

Note, this isn't quite as robust as Frontend - which checks for any placeholders *after* expected placeholders have been populated - but it should still give us some confidence here. I haven't mirrored the Frontend approach, because the validation and rendering stages are separate in the Contributions Service so a simple port is not possible.
