### PR TITLE
Pre populate placeholders

### DIFF
--- a/src/components/modules/ContributionsEpic.tsx
+++ b/src/components/modules/ContributionsEpic.tsx
@@ -3,33 +3,11 @@ import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
-import { getCountryName, getLocalCurrencySymbol } from '../../lib/geolocation';
 import { EpicTracking } from '../ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../../lib/variants';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from '../ContributionsEpicTicker';
-
-const replacePlaceholders = (
-    content: string,
-    numArticles: number,
-    countryCode?: string,
-): string => {
-    // Replace currency symbol placeholder with actual currency symbol
-    // Function uses default currency symbol so countryCode is not strictly required here
-    content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
-
-    // Replace number of viewed articles
-    // Value could be zero but we'll replace anyway
-    content = content.replace(/%%ARTICLE_COUNT%%/g, numArticles.toString());
-
-    // Replace country code placeholder with actual country name
-    // Should only replace if we were able to determine the country name from country code
-    const countryName = getCountryName(countryCode) ?? '';
-    content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;
-
-    return content;
-};
 
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
@@ -98,61 +76,47 @@ export type EpicProps = {
     variant: Variant;
     tracking: EpicTracking;
     countryCode?: string;
-    numArticles: number;
     onReminderOpen?: Function;
 };
 
 type HighlightedProps = {
     highlightedText: string;
-    countryCode?: string;
-    numArticles: number;
 };
 
 type BodyProps = {
-    variant: Variant;
-    countryCode?: string;
-    numArticles: number;
+    paragraphs: string[];
+    highlightedText?: string;
 };
 
 interface OnReminderOpen {
     buttonCopyAsString: string;
 }
 
-const Highlighted: React.FC<HighlightedProps> = ({
-    highlightedText,
-    countryCode,
-    numArticles,
-}: HighlightedProps) => (
+const Highlighted: React.FC<HighlightedProps> = ({ highlightedText }: HighlightedProps) => (
     <strong className={highlightWrapperStyles}>
         {' '}
         <span
             className={highlightStyles}
             dangerouslySetInnerHTML={{
-                __html: replacePlaceholders(highlightedText, numArticles, countryCode),
+                __html: highlightedText,
             }}
         />
     </strong>
 );
 
-const EpicBody: React.FC<BodyProps> = ({ variant, countryCode, numArticles }: BodyProps) => {
-    const { paragraphs, highlightedText } = variant;
-
+const EpicBody: React.FC<BodyProps> = ({ paragraphs, highlightedText }: BodyProps) => {
     return (
         <>
             {paragraphs.map((paragraph, idx) => (
                 <p key={idx} className={bodyStyles}>
                     <span
                         dangerouslySetInnerHTML={{
-                            __html: replacePlaceholders(paragraph, numArticles, countryCode),
+                            __html: paragraph,
                         }}
                     />
 
                     {highlightedText && idx === paragraphs.length - 1 && (
-                        <Highlighted
-                            highlightedText={highlightedText}
-                            countryCode={countryCode}
-                            numArticles={numArticles}
-                        />
+                        <Highlighted highlightedText={highlightedText} />
                     )}
                 </p>
             ))}
@@ -163,12 +127,12 @@ const EpicBody: React.FC<BodyProps> = ({ variant, countryCode, numArticles }: Bo
 export const ContributionsEpic: React.FC<EpicProps> = ({
     variant,
     tracking,
-    countryCode,
-    numArticles,
     onReminderOpen,
+    countryCode,
 }: EpicProps) => {
     const [isReminderActive, setIsReminderActive] = useState(false);
-    const { heading, backgroundImageUrl, showReminderFields, tickerSettings } = variant;
+    const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
+    const { heading, paragraphs, highlightedText } = variant;
 
     return (
         <section className={wrapperStyles}>
@@ -194,12 +158,12 @@ export const ContributionsEpic: React.FC<EpicProps> = ({
                 <h2
                     className={headingStyles}
                     dangerouslySetInnerHTML={{
-                        __html: replacePlaceholders(heading, numArticles, countryCode),
+                        __html: heading,
                     }}
                 />
             )}
 
-            <EpicBody variant={variant} countryCode={countryCode} numArticles={numArticles} />
+            <EpicBody paragraphs={paragraphs} highlightedText={highlightedText} />
 
             {!isReminderActive && (
                 <ContributionsEpicButtons

--- a/src/lib/placeholders.test.ts
+++ b/src/lib/placeholders.test.ts
@@ -1,0 +1,13 @@
+import { containsPlaceholder } from './placeholders';
+
+describe('placeholder handling', () => {
+    it('returns true if string contains placeholder', () => {
+        const got = containsPlaceholder('apple %%SOME_PLACEHOLDER%%');
+        expect(got).toBe(true);
+    });
+
+    it('returns false if string does not contain placeholder', () => {
+        const got = containsPlaceholder('apple without placeholder');
+        expect(got).toBe(false);
+    });
+});

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,0 +1,21 @@
+import { getCountryName, getLocalCurrencySymbol } from './geolocation';
+
+export const replacePlaceholders = (
+    content: string | undefined,
+    numArticles: number,
+    countryCode?: string,
+): string => {
+    if (!content) {
+        return '';
+    }
+
+    content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
+    content = content.replace(/%%ARTICLE_COUNT%%/g, numArticles.toString());
+
+    const countryName = getCountryName(countryCode) ?? '';
+    content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;
+
+    return content;
+};
+
+export const containsPlaceholder = (text: string): boolean => text.includes('%%');

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -14,6 +14,8 @@ import {
     userInTest,
     hasNoZeroArticleCount,
     isNotExpired,
+    hasNoPlaceholders,
+    populatePlaceholders,
 } from './variants';
 import { EpicTargeting } from '../components/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -45,7 +47,7 @@ const testDefault: Test = {
                 '',
             ],
             highlightedText:
-                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+                'Support the Guardian from as little as £1 – and it only takes a minute. Thank you.',
             cta: {
                 text: 'Support The Guardian',
                 baseUrl: 'https://support.theguardian.com/contribute',
@@ -738,6 +740,25 @@ describe('isNotExpired filter', () => {
         const filter = isNotExpired(now);
 
         const got = filter.test(test, targetingDefault);
+
+        expect(got).toBe(false);
+    });
+});
+
+describe('hasNoPlaceholders filter', () => {
+    it('should pass if no placeholders found', () => {
+        // nb. value of numArticles (set here to 3) is required but irrelevant to test
+        const populatedTest = populatePlaceholders(testDefault, 3, targetingDefault.countryCode);
+        const got = hasNoPlaceholders.test(populatedTest, targetingDefault);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail if placeholders found', () => {
+        const variant = testDefault.variants[0];
+        variant.heading = 'With placeholder %%CURRENCY_SYMBOL%%';
+        const test: Test = { ...testDefault, variants: [variant] };
+        const got = hasNoPlaceholders.test(test, targetingDefault);
 
         expect(got).toBe(false);
     });


### PR DESCRIPTION
## What does this change?

An alternative to https://github.com/guardian/contributions-service/pull/174, but this time closer to the Frontend implementation. The aim is to guarantee that users are never served variants with placeholders leftover ('%%...%%').

## How can we measure success?

If it is not horribly slow (I'll run some benchmarks) this approach seems superior to the alternative PR both in terms of simplicity and reliability.
