### PR TITLE
Check the heading for unreplaced placeholders

### DIFF
--- a/src/components/modules/ContributionsEpic.tsx
+++ b/src/components/modules/ContributionsEpic.tsx
@@ -156,7 +156,7 @@ export const ContributionsEpic: React.FC<EpicProps> = ({
         replacePlaceholders(paragraph, numArticles, countryCode),
     );
 
-    if ([cleanHighlighted, cleanHighlighted, ...cleanParagraphs].some(containsPlaceholder)) {
+    if ([cleanHighlighted, cleanHeading, ...cleanParagraphs].some(containsPlaceholder)) {
         return null; // quick exit if something goes wrong. Ideally we'd throw and caller would catch/log but TODO that separately
     }
 


### PR DESCRIPTION
Small tweak after I noticed this when looking over #177.

## What does this change?

Ensure that we check the epic heading text for unreplaced placeholders. We were checking the highlighted text twice previously.

## How can we measure success?

It shouldn't be possible for readers to be served an epic with unreplaced placeholders in the title, e.g. `%%COUNTRY_NAME%%`.

## What is the cost of failure?

It's not disastrous it a user see's a placeholder, but it looks a bit messy.