### PR TITLE
Fix banner module path in prod

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -286,7 +286,7 @@ app.get(
         try {
             const path = isDev
                 ? '/../dist/modules/banners/contributions/AusMomentContributionsBanner.js'
-                : '/modules/anners/contributions/AusMomentContributionsBanner.js';
+                : '/modules/banners/contributions/AusMomentContributionsBanner.js';
             const module = await fs.promises.readFile(__dirname + path);
 
             res.type('js');


### PR DESCRIPTION
Fixes issue with https://github.com/guardian/contributions-service/pull/182 where banner module is not found.