### PR TITLE
Module size improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 cloudformation.yaml
 cdk.out/
 .idea/
+stats/

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "rollup-plugin-filesize": "^9.0.1",
     "rollup-plugin-sourcemaps": "^0.6.2",
     "rollup-plugin-terser": "^5.3.0",
+    "rollup-plugin-visualizer": "^4.0.4",
     "supertest": "^4.0.2",
     "ts-jest": "^24.3.0",
     "ts-loader": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@emotion/core": "^10.0.27",
     "@guardian/src-brand": "^1.8.0",
     "@guardian/src-button": "^1.8.0",
-    "@guardian/src-ed-lines": "^1.8.0",
     "@guardian/src-foundations": "^1.8.0",
     "@guardian/src-icons": "^1.8.0",
     "@guardian/src-link": "^1.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 import externalGlobals from 'rollup-plugin-external-globals';
 import babel from '@rollup/plugin-babel';
 import filesize from 'rollup-plugin-filesize';
+import visualizer from 'rollup-plugin-visualizer';
 
 const tsOpts = {
     target: 'es2018',
@@ -26,16 +27,17 @@ const globals = {
 };
 
 const config = [
-    ['src/components/modules/epics/ContributionsEpic.tsx', 'dist/modules/epics/Epic.js'],
+    ['epic', 'src/components/modules/epics/ContributionsEpic.tsx', 'dist/modules/epics/Epic.js'],
     [
+        'aus-banner',
         'src/components/modules/banners/contributions/AusMomentContributionsBanner.tsx',
         'dist/modules/banners/contributions/AusMomentContributionsBanner.js',
     ],
-].map(([entryPoint, name]) => {
+].map(([name, entryPoint, target]) => {
     return {
         input: entryPoint,
         output: {
-            file: name,
+            file: target,
             format: 'es',
             sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
         },
@@ -64,6 +66,10 @@ const config = [
             terser({ compress: { global_defs: { 'process.env.NODE_ENV': 'production' } } }),
             externalGlobals(globals),
             filesize(),
+
+            // Note, visualizer is useful for *relative* sizes, but reports
+            // pre-minification.
+            visualizer({ sourcemap: true, gzipSize: true, filename: `stats/${name}.html` }),
         ],
     };
 });

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,12 +34,14 @@ const config = [
         'dist/modules/banners/contributions/AusMomentContributionsBanner.js',
     ],
 ].map(([name, entryPoint, target]) => {
+    const isProd = process.env.NODE_ENV === 'production';
+
     return {
         input: entryPoint,
         output: {
             file: target,
             format: 'es',
-            sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
+            sourcemap: isProd ? false : 'inline',
         },
         external: id => Object.keys(globals).some(key => id.startsWith(key)),
         plugins: [
@@ -69,7 +71,7 @@ const config = [
 
             // Note, visualizer is useful for *relative* sizes, but reports
             // pre-minification.
-            visualizer({ sourcemap: true, gzipSize: true, filename: `stats/${name}.html` }),
+            visualizer({ sourcemap: !isProd, gzipSize: true, filename: `stats/${name}.html` }),
         ],
     };
 });

--- a/src/components/Lines.tsx
+++ b/src/components/Lines.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { css } from 'emotion';
+import { border } from '@guardian/src-foundations/palette';
+import { remSpace } from '@guardian/src-foundations';
+
+const lineGap = remSpace[1];
+
+const straightLines = css`
+    background-image: repeating-linear-gradient(
+        to bottom,
+        ${border.secondary},
+        ${border.secondary} 1px,
+        transparent 1px,
+        transparent ${lineGap}
+    );
+    background-repeat: repeat-x;
+    background-position: top;
+
+    background-size: 1px calc(${lineGap} * 3 + 1px);
+    height: calc(${lineGap} * 3 + 1px);
+`;
+
+// Note, we should replace with @guardian/src-ed-lines once it is smaller in
+// size/better suited to tree-shaking.
+export const Lines: React.FC<{}> = ({}) => {
+    return <div className={straightLines} />;
+};

--- a/src/components/modules/banners/subscriptions/subscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/subscriptions/subscriptionsBannerStyles.ts
@@ -1,5 +1,5 @@
 import { css } from 'emotion';
-import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
+import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';

--- a/src/components/modules/banners/weekly/weeklyBannerStyles.ts
+++ b/src/components/modules/banners/weekly/weeklyBannerStyles.ts
@@ -1,5 +1,5 @@
 import { css } from 'emotion';
-import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
+import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -4,7 +4,7 @@ import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { ReminderFields } from '../../../lib/variants';
-import { Lines } from '@guardian/src-ed-lines'; // TODO remove as too big
+import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgClose } from '@guardian/src-svgs';

--- a/src/components/modules/epics/ContributionsEpicTicker.tsx
+++ b/src/components/modules/epics/ContributionsEpicTicker.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq/cjs';
-import { headline } from '@guardian/src-foundations/typography/cjs';
+import { from } from '@guardian/src-foundations/mq';
+import { headline } from '@guardian/src-foundations/typography';
 import { useHasBeenSeen, HasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { TickerSettings } from '../../../lib/variants';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,13 +1327,6 @@
     "@guardian/src-helpers" "^1.8.0"
     "@guardian/src-icons" "^1.8.0"
 
-"@guardian/src-ed-lines@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-ed-lines/-/src-ed-lines-1.8.0.tgz#875769d207f6346a977121c1e642354fe7d7b003"
-  integrity sha512-EWJoTRSOjM/xoS3VM5BsbDfJVpnMkUX8bEuoscOqa7RZSHyL7+rJWvehbAoyd+L1ubvDoGrDf3JVoBwqohWT+g==
-  dependencies:
-    "@guardian/src-helpers" "^1.8.0"
-
 "@guardian/src-foundations@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.8.0.tgz#4b2276d849917471c3cc46e25fd952eb35c3e40a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9293,6 +9293,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
+nanoid@^3.0.1:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.10.tgz#69a8a52b77892de0d11cede96bc9762852145bc4"
+  integrity sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9755,7 +9760,7 @@ open@^6.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-open@^7.0.0:
+open@^7.0.0, open@^7.0.3:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/open/-/open-7.0.4.tgz#c28a9d315e5c98340bf979fdcb2e58664aa10d83"
   integrity sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==
@@ -10585,7 +10590,7 @@ punycode@^1.2.4:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-pupa@^2.0.1:
+pupa@^2.0.0, pupa@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.0.1.tgz#dbdc9ff48ffbea4a26a069b6f9f7abb051008726"
   integrity sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
@@ -11466,6 +11471,17 @@ rollup-plugin-terser@^5.3.0:
     serialize-javascript "^2.1.2"
     terser "^4.6.2"
 
+rollup-plugin-visualizer@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-4.0.4.tgz#69b9140c6faf46328997ed2d08b974252bf9d683"
+  integrity sha512-odkyLiVxCEXh4AWFSl75+pbIapzhEZkOVww8pKUgraOHicSH67MYMnAOHWQVK/BYeD1cCiF/0kk8/XNX2+LM9A==
+  dependencies:
+    nanoid "^3.0.1"
+    open "^7.0.3"
+    pupa "^2.0.0"
+    source-map "^0.7.3"
+    yargs "^15.0.0"
+
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -11947,6 +11963,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"
@@ -13534,7 +13555,7 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.1:
+yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -13574,6 +13595,23 @@ yargs@^14.0.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+yargs@^15.0.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^15.1.0, yargs@^15.3.1:
   version "15.3.1"


### PR DESCRIPTION
## What does this change?

A few changes to reduce the epic module bundle size.

Initially:

![Screenshot 2020-07-15 at 15 18 42](https://user-images.githubusercontent.com/858402/87556477-9daa1500-c6ae-11ea-855a-3b6f8db7885c.png)

after switching away from `cjs` src imports:

![Screenshot 2020-07-15 at 15 19 06](https://user-images.githubusercontent.com/858402/87556483-9e42ab80-c6ae-11ea-9d3d-cca50f6cec3a.png)

after inlining `Lines` and dropping `@guardian/src-ed-lines` for now:

![Screenshot 2020-07-15 at 15 19 15](https://user-images.githubusercontent.com/858402/87556486-9edb4200-c6ae-11ea-8184-91a2f2987a33.png)

## How can we measure success?

See above: a ~30% reduction in gzipped size.

--

For a sense of what's left see below. Note, visualizer runs pre-minification so the actual numbers are not correct; what matters is the relevant sizes here.

![Screenshot 2020-07-15 at 15 00 43](https://user-images.githubusercontent.com/858402/87559727-92f17f00-c6b2-11ea-824d-542e022ef992.png)
