### PR TITLE
Add article count opt out

### DIFF
--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -113,18 +113,18 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
 
-    const overlayRef = useRef<HTMLDivElement>(null);
+    const optOutRef = useRef<HTMLDivElement>(null);
 
-    const clickWasOutsideOverlay = (event: MouseEvent): boolean => {
-        if (overlayRef.current) {
-            return !overlayRef.current.contains(event.target as Node);
+    const clickWasOutsideOptOut = (event: MouseEvent): boolean => {
+        if (optOutRef.current) {
+            return !optOutRef.current.contains(event.target as Node);
         } else {
             return true;
         }
     };
 
     const handleClick = (event: MouseEvent): void => {
-        if (clickWasOutsideOverlay(event)) {
+        if (clickWasOutsideOptOut(event)) {
             setIsOpen(false);
         }
     };
@@ -153,12 +153,12 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     };
 
     return (
-        <div className={optOutContainer}>
+        <div className={optOutContainer} ref={optOutRef}>
             <button className={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
                 {`${numArticles}${nextWord ? nextWord : ''}`}
             </button>
             {isOpen && (
-                <div className={overlayContainer} ref={overlayRef}>
+                <div className={overlayContainer}>
                     <div className={overlayHeader}>
                         <div className={overlayHeaderText}>
                             {hasOptedOut ? "You've opted out" : "What's this?"}

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -86,8 +86,8 @@ const overlayNote = css`
     }
 
     a {
-        color: #ffffff;
-        text-decoration: underline;
+        color: #ffffff !important;
+        text-decoration: underline !important;
     }
 `;
 

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -4,6 +4,7 @@ import { brand } from '@guardian/src-foundations/palette';
 import { textSans, body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
+import { SvgClose } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { brand as brandTheme } from '@guardian/src-foundations/themes';
 import { from } from '@guardian/src-foundations/mq';
@@ -43,6 +44,12 @@ const overlayContainer = css`
 `;
 
 const overlayHeader = css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+`;
+
+const overlayHeaderText = css`
     font-size: 17px;
     font-weight: bold;
 `;
@@ -77,6 +84,11 @@ const overlayNote = css`
     ${from.tablet} {
         display: block;
     }
+
+    a {
+        color: #ffffff;
+        text-decoration: underline;
+    }
 `;
 
 export interface ArticleCountOptOutProps {
@@ -87,36 +99,65 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     numArticles,
 }: ArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
+    const [hasOptedOut, setHasOptedOut] = useState(false);
 
     return (
         <div className={optOutContainer}>
-            <button className={articleCountButton} onClick={() => setIsOpen(!isOpen)}>
+            <button className={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
                 {numArticles} articles
             </button>
             {isOpen && (
                 <div className={overlayContainer}>
-                    <div className={overlayHeader}>What's this?</div>
+                    <div className={overlayHeader}>
+                        <div className={overlayHeaderText}>
+                            {hasOptedOut ? "You've opted out" : "What's this?"}
+                        </div>
+                        {hasOptedOut && (
+                            <Button
+                                onClick={(): void => setIsOpen(false)}
+                                icon={<SvgClose />}
+                                hideLabel
+                                size="small"
+                            ></Button>
+                        )}
+                    </div>
 
                     <div className={overlayBody}>
-                        We would like to remind you how many Guardian articles you’ve enjoyed on
-                        this device. Can we continue showing you this?
+                        {hasOptedOut
+                            ? "Starting from your next page view, we won't count the articles you read or show you this message for three months."
+                            : 'We would like to remind you how many Guardian articles you’ve enjoyed on this device. Can we continue showing you this?'}
                     </div>
 
-                    <div className={overlayCtaContainer}>
-                        <ThemeProvider theme={brandTheme}>
-                            <Button priority="tertiary" size="small">
-                                Yes, that's OK
-                            </Button>
-                        </ThemeProvider>
-                        <ThemeProvider theme={brandTheme}>
-                            <Button priority="primary" size="small">
-                                No, opt me out
-                            </Button>
-                        </ThemeProvider>
-                    </div>
+                    {!hasOptedOut && (
+                        <div className={overlayCtaContainer}>
+                            <ThemeProvider theme={brandTheme}>
+                                <Button priority="tertiary" size="small">
+                                    Yes, that&apos;s OK
+                                </Button>
+                            </ThemeProvider>
+                            <ThemeProvider theme={brandTheme}>
+                                <Button
+                                    onClick={(): void => setHasOptedOut(true)}
+                                    priority="primary"
+                                    size="small"
+                                >
+                                    No, opt me out
+                                </Button>
+                            </ThemeProvider>
+                        </div>
+                    )}
 
                     <div className={overlayNote}>
-                        Please note you cannot undo this action or opt back in
+                        {hasOptedOut ? (
+                            <span>
+                                If you have any questions, please{' '}
+                                <a href="https://www.theguardian.com/help/contact-us">
+                                    contact us.
+                                </a>
+                            </span>
+                        ) : (
+                            'Please note you cannot undo this action or opt back in.'
+                        )}
                     </div>
                 </div>
             )}

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { css } from 'emotion';
+import { brand } from '@guardian/src-foundations/palette';
+import { textSans, body } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+import { Button } from '@guardian/src-button';
+import { ThemeProvider } from 'emotion-theming';
+import { brand as brandTheme } from '@guardian/src-foundations/themes';
+import { from } from '@guardian/src-foundations/mq';
+
+const optOutContainer = css`
+    display: inline-block;
+
+    ${from.tablet} {
+        position: relative;
+    }
+`;
+
+const articleCountButton = css`
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    ${body.medium()}
+`;
+
+const overlayContainer = css`
+    position: absolute;
+    left: ${space[4]}px;
+    right: ${space[4]}px;
+    color: #ffffff;
+    background: ${brand[400]};
+    ${textSans.medium()}
+    padding: ${space[3]}px;
+
+
+    ${from.tablet} {
+        width: 325px;
+        left: 0;
+        padding-bottom: ${space[4]}px;
+    }
+`;
+
+const overlayHeader = css`
+    font-size: 17px;
+    font-weight: bold;
+`;
+
+const overlayBody = css`
+    margin-top: ${space[1]}px;
+    font-size: 15px;
+`;
+
+const overlayCtaContainer = css`
+    margin-top: ${space[5]}px;
+    > * + * {
+        margin-top: ${space[3]}px;
+    }
+
+    ${from.mobileMedium} {
+        display: flex;
+
+        > * + * {
+            margin-top: 0;
+            margin-left: ${space[3]}px;
+        }
+    }
+`;
+
+const overlayNote = css`
+    margin-top: ${space[3]}px;
+    ${textSans.xsmall()}
+    font-style: italic;
+    display: none;
+
+    ${from.tablet} {
+        display: block;
+    }
+`;
+
+export interface ArticleCountOptOutProps {
+    numArticles: number;
+}
+
+export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
+    numArticles,
+}: ArticleCountOptOutProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <div className={optOutContainer}>
+            <button className={articleCountButton} onClick={() => setIsOpen(!isOpen)}>
+                {numArticles} articles
+            </button>
+            {isOpen && (
+                <div className={overlayContainer}>
+                    <div className={overlayHeader}>What's this?</div>
+
+                    <div className={overlayBody}>
+                        We would like to remind you how many Guardian articles you’ve enjoyed on
+                        this device. Can we continue showing you this?
+                    </div>
+
+                    <div className={overlayCtaContainer}>
+                        <ThemeProvider theme={brandTheme}>
+                            <Button priority="tertiary" size="small">
+                                Yes, that's OK
+                            </Button>
+                        </ThemeProvider>
+                        <ThemeProvider theme={brandTheme}>
+                            <Button priority="primary" size="small">
+                                No, opt me out
+                            </Button>
+                        </ThemeProvider>
+                    </div>
+
+                    <div className={overlayNote}>
+                        Please note you cannot undo this action or opt back in
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { css } from 'emotion';
 import { brand } from '@guardian/src-foundations/palette';
-import { textSans, body } from '@guardian/src-foundations/typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { SvgClose } from '@guardian/src-icons';
@@ -32,7 +32,9 @@ const articleCountButton = css`
     padding: 0;
     cursor: pointer;
     text-decoration: underline;
-    ${body.medium()}
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
 `;
 
 const overlayContainer = css`

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -37,6 +37,7 @@ const articleCountButton = css`
 
 const overlayContainer = css`
     position: absolute;
+    z-index: 100;
     left: ${space[4]}px;
     right: ${space[4]}px;
     color: #ffffff;

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { css } from 'emotion';
 import { brand } from '@guardian/src-foundations/palette';
 import { textSans, body } from '@guardian/src-foundations/typography';
@@ -101,13 +101,34 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
 
+    const overlayRef = useRef<HTMLDivElement>(null);
+
+    const clickWasOutsideOverlay = (event: MouseEvent): boolean => {
+        if (overlayRef.current) {
+            return !overlayRef.current.contains(event.target as Node);
+        } else {
+            return true;
+        }
+    };
+
+    const handleClick = (event: MouseEvent): void => {
+        if (clickWasOutsideOverlay(event)) {
+            setIsOpen(false);
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener('mousedown', handleClick);
+        return (): void => document.removeEventListener('mousedown', handleClick);
+    }, []);
+
     return (
         <div className={optOutContainer}>
             <button className={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
                 {numArticles} articles
             </button>
             {isOpen && (
-                <div className={overlayContainer}>
+                <div className={overlayContainer} ref={overlayRef}>
                     <div className={overlayHeader}>
                         <div className={overlayHeaderText}>
                             {hasOptedOut ? "You've opted out" : "What's this?"}

--- a/src/components/modules/epics/ContributionsEpic.testData.ts
+++ b/src/components/modules/epics/ContributionsEpic.testData.ts
@@ -78,6 +78,7 @@ const targeting: EpicTargeting = {
         { week: 18337, count: 10 },
         { week: 18330, count: 5 },
     ],
+    hasOptedOutOfArticleCount: false,
     countryCode: 'GB',
 };
 

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -130,17 +130,19 @@ const EpicHeader: React.FC<EpicHeaderProps> = ({ text, numArticles }: EpicHeader
     return <h2 className={headingStyles}>{elements}</h2>;
 };
 
-const Highlighted: React.FC<HighlightedProps> = ({ highlightedText }: HighlightedProps) => (
-    <strong className={highlightWrapperStyles}>
-        {' '}
-        <span
-            className={highlightStyles}
-            dangerouslySetInnerHTML={{
-                __html: highlightedText,
-            }}
-        />
-    </strong>
-);
+const Highlighted: React.FC<HighlightedProps> = ({
+    highlightedText,
+    numArticles,
+}: HighlightedProps) => {
+    const elements = replaceArticleCount(highlightedText, numArticles);
+
+    return (
+        <strong className={highlightWrapperStyles}>
+            {' '}
+            <span className={highlightStyles}>{elements}</span>
+        </strong>
+    );
+};
 
 interface EpicBodyParagraphProps {
     paragraph: string;

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -3,7 +3,10 @@ import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
-import { replacePlaceholders, containsPlaceholder } from '../../../lib/placeholders';
+import {
+    replaceNonArticleCountPlaceholders,
+    containsNonArticleCountPlaceholder,
+} from '../../../lib/placeholders';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../../../lib/variants';
@@ -198,14 +201,21 @@ export const ContributionsEpic: React.FC<EpicProps> = ({
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
 
-    const cleanHighlighted = replacePlaceholders(variant.highlightedText, countryCode);
-    const cleanHeading = replacePlaceholders(variant.heading, countryCode);
+    const cleanHighlighted = replaceNonArticleCountPlaceholders(
+        variant.highlightedText,
+        countryCode,
+    );
+    const cleanHeading = replaceNonArticleCountPlaceholders(variant.heading, countryCode);
 
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
-        replacePlaceholders(paragraph, countryCode),
+        replaceNonArticleCountPlaceholders(paragraph, countryCode),
     );
 
-    if ([cleanHighlighted].some(containsPlaceholder)) {
+    if (
+        [cleanHighlighted, cleanHeading, ...cleanParagraphs].some(
+            containsNonArticleCountPlaceholder,
+        )
+    ) {
         return null; // quick exit if something goes wrong. Ideally we'd throw and caller would catch/log but TODO that separately
     }
 

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -122,7 +122,7 @@ const EpicBodyParagraph: React.FC<EpicBodyParagraphProps> = ({
     numArticles,
     highlighted,
 }: EpicBodyParagraphProps) => {
-    let nextWords: Array<string | null> = [];
+    const nextWords: Array<string | null> = [];
     const subbedParagraph = paragraph.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
         nextWords.push(nextWord);
         return '%%ARTICLE_COUNT_AND_NEXT_WORD%%';

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -182,11 +182,11 @@ export const ContributionsEpic: React.FC<EpicProps> = ({
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
 
-    const cleanHighlighted = replacePlaceholders(variant.highlightedText, numArticles, countryCode);
-    const cleanHeading = replacePlaceholders(variant.heading, numArticles, countryCode);
+    const cleanHighlighted = replacePlaceholders(variant.highlightedText, countryCode);
+    const cleanHeading = replacePlaceholders(variant.heading, countryCode);
 
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
-        replacePlaceholders(paragraph, numArticles, countryCode),
+        replacePlaceholders(paragraph, countryCode),
     );
 
     if ([cleanHighlighted, cleanHeading].some(containsPlaceholder)) {

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -53,6 +53,7 @@ export type EpicTargeting = {
     epicViewLog?: ViewLog;
     countryCode?: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
+    hasOptedOutOfArticleCount: boolean;
 
     // Note, it turns out that showSupportMessaging (defined in the Members Data
     // API) does not capture every case of recurring contributors or last

--- a/src/factories/targeting.ts
+++ b/src/factories/targeting.ts
@@ -10,4 +10,5 @@ export default Factory.define<EpicTargeting>(() => ({
     isRecurringContributor: false,
     tags: [],
     showSupportMessaging: true,
+    hasOptedOutOfArticleCount: false,
 }));

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,0 +1,48 @@
+const ERR_INVALID_COOKIE_NAME = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;
+
+// subset of https://github.com/guzzle/guzzle/pull/1131
+const isValidCookieValue = (name: string): boolean => !/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+
+const getShortDomain = (isCrossSubdomain = false): string => {
+    const domain = document.domain || '';
+
+    if (domain === 'localhost') {
+        return domain;
+    }
+
+    // Trim any possible subdomain (will be shared with supporter, identity, etc)
+    if (isCrossSubdomain) {
+        return ['', ...domain.split('.').slice(-2)].join('.');
+    }
+    // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+    return domain.replace(/^(www|m\.code|dev|m)\./, '.');
+};
+
+const getDomainAttribute = (isCrossSubdomain = false): string => {
+    const shortDomain = getShortDomain(isCrossSubdomain);
+    return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+};
+
+export const addCookie = (
+    name: string,
+    value: string,
+    daysToLive?: number,
+    isCrossSubdomain: boolean = false,
+): void => {
+    const expires = new Date();
+
+    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+        throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
+    }
+
+    if (daysToLive) {
+        expires.setDate(expires.getDate() + daysToLive);
+    } else {
+        expires.setMonth(expires.getMonth() + 5);
+        expires.setDate(1);
+    }
+
+    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+        isCrossSubdomain,
+    )}`;
+};

--- a/src/lib/placeholders.test.ts
+++ b/src/lib/placeholders.test.ts
@@ -1,9 +1,14 @@
 import { containsNonArticleCountPlaceholder } from './placeholders';
 
-describe('containsPlaceholder', () => {
-    it('returns true if string contains placeholder', () => {
+describe('containsNonArticleCountPlaceholder', () => {
+    it('returns true if string contains placeholder (that is not %%ARTICLE_COUNT%%)', () => {
         const got = containsNonArticleCountPlaceholder('apple %%SOME_PLACEHOLDER%%');
         expect(got).toBe(true);
+    });
+
+    it('returns false if string contains an article count placeholder', () => {
+        const got = containsNonArticleCountPlaceholder('apple %%ARTICLE_COUNT%%');
+        expect(got).toBe(false);
     });
 
     it('returns false if string does not contain placeholder', () => {

--- a/src/lib/placeholders.test.ts
+++ b/src/lib/placeholders.test.ts
@@ -1,13 +1,13 @@
-import { containsPlaceholder } from './placeholders';
+import { containsNonArticleCountPlaceholder } from './placeholders';
 
 describe('containsPlaceholder', () => {
     it('returns true if string contains placeholder', () => {
-        const got = containsPlaceholder('apple %%SOME_PLACEHOLDER%%');
+        const got = containsNonArticleCountPlaceholder('apple %%SOME_PLACEHOLDER%%');
         expect(got).toBe(true);
     });
 
     it('returns false if string does not contain placeholder', () => {
-        const got = containsPlaceholder('apple without placeholder');
+        const got = containsNonArticleCountPlaceholder('apple without placeholder');
         expect(got).toBe(false);
     });
 });

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,10 +1,6 @@
 import { getCountryName, getLocalCurrencySymbol } from './geolocation';
 
-export const replacePlaceholders = (
-    content: string | undefined,
-    numArticles: number,
-    countryCode?: string,
-): string => {
+export const replacePlaceholders = (content: string | undefined, countryCode?: string): string => {
     if (!content) {
         return '';
     }

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,6 +1,11 @@
 import { getCountryName, getLocalCurrencySymbol } from './geolocation';
 
-export const replacePlaceholders = (content: string | undefined, countryCode?: string): string => {
+// we have to treat %%ARTICLE_COUNT%% placeholders specially as they are replaced
+// with react components, not a simple text substitution
+export const replaceNonArticleCountPlaceholders = (
+    content: string | undefined,
+    countryCode?: string,
+): string => {
     if (!content) {
         return '';
     }
@@ -13,4 +18,8 @@ export const replacePlaceholders = (content: string | undefined, countryCode?: s
     return content;
 };
 
-export const containsPlaceholder = (text: string): boolean => text.includes('%%');
+// this regex matches %% that are neither preceeded by %%ARTICLE_COUNT or followed by
+// ARTICLE_COUNT%%
+const NON_ARTICLE_COUNT_PLACEHOLDER_REGEX = /(?<!%%ARTICLE_COUNT)%%(?!ARTICLE_COUNT%%)/;
+export const containsNonArticleCountPlaceholder = (text: string): boolean =>
+    NON_ARTICLE_COUNT_PLACEHOLDER_REGEX.test(text);

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -10,7 +10,6 @@ export const replacePlaceholders = (
     }
 
     content = content.replace(/%%CURRENCY_SYMBOL%%/g, getLocalCurrencySymbol(countryCode));
-    content = content.replace(/%%ARTICLE_COUNT%%/g, numArticles.toString());
 
     const countryName = getCountryName(countryCode) ?? '';
     content = countryName ? content.replace(/%%COUNTRY_NAME%%/g, countryName) : content;

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -76,6 +76,7 @@ const targetingDefault: EpicTargeting = {
     isRecurringContributor: false,
     lastOneOffContributionDate: undefined,
     mvtId: 2,
+    hasOptedOutOfArticleCount: false,
 };
 
 describe('findTestAndVariant', () => {
@@ -96,11 +97,12 @@ describe('findTestAndVariant', () => {
         expect(got?.result?.variant.name).toBe('control-example-1');
     });
 
-    it('should return undefined if test has articlesViewedSettings', () => {
+    it('should return undefined if test has articlesViewedSettings and user has opted out of article count', () => {
         const tests = [testDefault];
         const targeting: EpicTargeting = {
             ...targetingDefault,
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
+            hasOptedOutOfArticleCount: true,
         };
 
         const got = findTestAndVariant(tests, targeting);

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -250,15 +250,6 @@ export const withinMaxViews = (log: ViewLog, now: Date = new Date()): Filter => 
     },
 });
 
-// Temporarily disable all epics with articlesViewedSettings, while we test a new feature in frontend:
-// https://github.com/guardian/frontend/pull/22546
-export const noArticleViewedSettings: Filter = {
-    id: 'noArticleViewedSettings',
-    test: (test): boolean => {
-        return !test.articlesViewedSettings;
-    },
-};
-
 export const withinArticleViewedSettings = (
     history: WeeklyArticleHistory,
     now: Date = new Date(),
@@ -327,6 +318,17 @@ export const isNotExpired = (now: Date = new Date()): Filter => ({
     },
 });
 
+export const optOutOfArticleCount: Filter = {
+    id: 'optOutOfArticleCount',
+    test: (test, targeting) => {
+        if (test.articlesViewedSettings) {
+            return !targeting.hasOptedOutOfArticleCount;
+        } else {
+            return true;
+        }
+    },
+};
+
 type FilterResults = { [filter: string]: boolean };
 
 export type Debug = { [test: string]: FilterResults };
@@ -362,9 +364,9 @@ export const findTestAndVariant = (
         matchesCountryGroups,
         withinMaxViews(targeting.epicViewLog || []),
         // withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
-        noArticleViewedSettings,
         isContentType,
         hasNoZeroArticleCount(),
+        optOutOfArticleCount,
     ];
 
     const priorityOrdered = ([] as Test[]).concat(

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -318,8 +318,8 @@ export const isNotExpired = (now: Date = new Date()): Filter => ({
     },
 });
 
-export const optOutOfArticleCount: Filter = {
-    id: 'optOutOfArticleCount',
+export const respectArticleCountOptOut: Filter = {
+    id: 'respectArticleCountOptOut',
     test: (test, targeting) => {
         if (test.articlesViewedSettings) {
             return !targeting.hasOptedOutOfArticleCount;
@@ -366,7 +366,7 @@ export const findTestAndVariant = (
         // withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
         isContentType,
         hasNoZeroArticleCount(),
-        optOutOfArticleCount,
+        respectArticleCountOptOut,
     ];
 
     const priorityOrdered = ([] as Test[]).concat(

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -94,6 +94,9 @@
                         ]
                     }
                 },
+                "hasOptedOutOfArticleCount": {
+                    "type": "boolean"
+                },
                 "showSupportMessaging": {
                     "type": "boolean"
                 },
@@ -106,6 +109,7 @@
             },
             "required": [
                 "contentType",
+                "hasOptedOutOfArticleCount",
                 "isMinuteArticle",
                 "isPaidContent",
                 "isRecurringContributor",


### PR DESCRIPTION
Implement the article view opt out for epics. Additionally, instead of never serving epics with article counts, we only prevent serving them if the user has opted out (as provided by the client). 

header mobile:

<img width="327" alt="Screenshot 2020-07-21 at 14 44 25" src="https://user-images.githubusercontent.com/17720442/88062918-5665cd80-cb61-11ea-800f-bd0276e20e01.png">

header tablet and above:

<img width="494" alt="Screenshot 2020-07-21 at 14 44 06" src="https://user-images.githubusercontent.com/17720442/88062955-61b8f900-cb61-11ea-88b2-cd54a2948cb7.png">

body mobile:

<img width="336" alt="Screenshot 2020-07-21 at 12 14 16" src="https://user-images.githubusercontent.com/17720442/88048736-c8331c80-cb4b-11ea-8411-57a32e6d7ef0.png">

body tablet and above: 
<img width="730" alt="Screenshot 2020-07-21 at 12 12 58" src="https://user-images.githubusercontent.com/17720442/88048622-9457f700-cb4b-11ea-8c1c-717cbda87c39.png">

highlight mobile:
<img width="311" alt="Screenshot 2020-07-22 at 08 32 28" src="https://user-images.githubusercontent.com/17720442/88148133-156bc880-cbf6-11ea-8905-fe4ecaaa6ffc.png">

highlight tablet and above:
<img width="782" alt="Screenshot 2020-07-22 at 08 32 04" src="https://user-images.githubusercontent.com/17720442/88148163-1f8dc700-cbf6-11ea-98a2-f7de9eda5b10.png">

