### PR TITLE
Add hear more link

### DIFF
--- a/src/components/modules/banners/contributions/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
+++ b/src/components/modules/banners/contributions/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
@@ -492,6 +492,11 @@ const supportTheGuardianLink = css`
     }
 `;
 
+const hearMoreLink = css`
+    ${textSans.medium()}
+    color: ${neutral[7]};
+`;
+
 const hearFromOurSupportersLink = css`
     ${textSans.medium()}
     font-weight: 700;
@@ -912,6 +917,12 @@ export const AusMomentThankYouBanner: React.FC<BannerProps> = ({
                                         )}
                                     >
                                         Support the Guardian
+                                    </a>
+                                    <a
+                                        className={hearMoreLink}
+                                        href="https://www.theguardian.com/membership/2020/jul/20/guardian-australia-reached-goalof-150000-supporters"
+                                    >
+                                        Hear more
                                     </a>
                                 </div>
                             )}

--- a/src/components/modules/banners/contributions/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
+++ b/src/components/modules/banners/contributions/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
@@ -920,7 +920,7 @@ export const AusMomentThankYouBanner: React.FC<BannerProps> = ({
                                     </a>
                                     <a
                                         className={hearMoreLink}
-                                        href="https://www.theguardian.com/membership/2020/jul/20/guardian-australia-reached-goalof-150000-supporters"
+                                        href="https://www.theguardian.com/membership/2020/jul/20/guardian-australia-reached-goalof-150000-supporters?INTCMP=Aus_moment_2020_frontend_banner_button"
                                     >
                                         Hear more
                                     </a>


### PR DESCRIPTION
Add 'hear more' secondary cta to the non supporter version of the banner

<img width="1300" alt="Screenshot 2020-07-20 at 08 19 22" src="https://user-images.githubusercontent.com/17720442/87910663-44e9cc00-ca62-11ea-985f-afef0a2d720d.png">
