### PR TITLE
remove AusMomentContributionsBanner from test list

### DIFF
--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -3,7 +3,6 @@ import {
     BannerTargeting,
     BannerTestSelection,
 } from '../../components/modules/banners/contributions/BannerTypes';
-import { AusMomentContributionsBanner } from './AusMomentContributionsBannerTest';
 import { AusMomentThankYouBanner } from './AusMomentThankYouBannerTest';
 import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
@@ -71,8 +70,6 @@ const redeployedSinceLastClosed = (targeting: BannerTargeting): Promise<boolean>
     }
 };
 
-const AUS_MOMENT_THANK_YOU_BANNER_LAUNCH_DATE = new Date('2020-07-19T23:30:00Z');
-
 // TODO - implement test selection properly
 export const selectBannerTest = (
     targeting: BannerTargeting,
@@ -81,12 +78,7 @@ export const selectBannerTest = (
 ): Promise<BannerTestSelection | null> => {
     return redeployedSinceLastClosed(targeting).then(hasRedeployed => {
         if (hasRedeployed) {
-            const now = new Date();
-            const tests = [
-                now < AUS_MOMENT_THANK_YOU_BANNER_LAUNCH_DATE
-                    ? AusMomentContributionsBanner
-                    : AusMomentThankYouBanner,
-            ];
+            const tests = [AusMomentThankYouBanner];
             const testToRun = tests.find(
                 test =>
                     targeting.alreadyVisitedCount >= test.minPageViews &&


### PR DESCRIPTION
The original moment banner is no longer in use.
Note - this does not remove the banner from the codebase, for now I'm just removing it from `bannerSelection` to simplify things for this PR https://github.com/guardian/contributions-service/pull/176