### PR TITLE
Add tracking to subscriptions banner CTAs

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -23,7 +23,7 @@ import {
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
-import { getSignInUrl, getSubscriptionUrl } from '../subscriptionsTracking';
+import { addTrackingParams } from '../../../../lib/tracking';
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,12 +36,8 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
-    const signInUrl = getSignInUrl('DigitalSubscription');
-    const subscriptionsUrl = getSubscriptionUrl(
-        'DigitalSubscription',
-        tracking.ophanPageId,
-        tracking.referrerUrl,
-    );
+    const signInUrl =
+        'https://theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
 
     return (
         <>
@@ -64,7 +60,13 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 opinion. <strong>Live</strong>, constantly by your side, keeping you
                                 connected with the outside world.
                             </p>
-                            <a className={linkStyle} href={subscriptionsUrl}>
+                            <a
+                                className={linkStyle}
+                                href={addTrackingParams(
+                                    'https://support.theguardian.com/subscribe/digital',
+                                    tracking,
+                                )}
+                            >
                                 <div
                                     id="js-site-message--subscription-banner__cta"
                                     data-link-name="subscription-banner : cta"

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -23,6 +23,7 @@ import {
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
+import { getSignInUrl, getSubscriptionUrl } from '../subscriptionsTracking';
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -35,6 +36,12 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
+    const signInUrl = getSignInUrl('DigitalSubscription');
+    const subscriptionsUrl = getSubscriptionUrl(
+        'DigitalSubscription',
+        tracking.ophanPageId,
+        tracking.referrerUrl,
+    );
 
     return (
         <>
@@ -57,10 +64,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 opinion. <strong>Live</strong>, constantly by your side, keeping you
                                 connected with the outside world.
                             </p>
-                            <a
-                                className={linkStyle}
-                                href="https://support.theguardian.com/uk/subscribe"
-                            >
+                            <a className={linkStyle} href={subscriptionsUrl}>
                                 <div
                                     id="js-site-message--subscription-banner__cta"
                                     data-link-name="subscription-banner : cta"
@@ -85,7 +89,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 Already a subscriber?{' '}
                                 <a
                                     id="js-site-message--subscription-banner__sign-in"
-                                    href="https://support.theguardian.com/uk/subscribe"
+                                    href={signInUrl}
                                     data-link-name="subscription-banner : sign in"
                                 >
                                     Sign in

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -21,6 +21,7 @@ import {
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
+import { getSignInUrl, getSubscriptionUrl } from '../subscriptionsTracking';
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -33,6 +34,12 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
+    const signInUrl = getSignInUrl('GuardianWeekly');
+    const subscriptionsUrl = getSubscriptionUrl(
+        'GuardianWeekly',
+        tracking.ophanPageId,
+        tracking.referrerUrl,
+    );
 
     return (
         <>
@@ -46,10 +53,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                 The Guardian Weekly, our essential world news magazine. Home
                                 delivery available wherever you are.
                             </p>
-                            <a
-                                className={linkStyle}
-                                href="https://support.theguardian.com/uk/subscribe"
-                            >
+                            <a className={linkStyle} href={subscriptionsUrl}>
                                 <div
                                     id="js-site-message--weekly-banner__cta"
                                     data-link-name="weekly-banner : cta"
@@ -71,10 +75,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a
-                                    href="https://www.theguardian.com"
-                                    data-link-name="weekly-banner : sign in"
-                                >
+                                <a href={signInUrl} data-link-name="weekly-banner : sign in">
                                     Sign in
                                 </a>{' '}
                                 to not see this again

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -21,7 +21,7 @@ import {
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
-import { getSignInUrl, getSubscriptionUrl } from '../subscriptionsTracking';
+import { addTrackingParams } from '../../../../lib/tracking';
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,17 +34,17 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
-    const signInUrl = getSignInUrl('GuardianWeekly');
-    const subscriptionsUrl = getSubscriptionUrl(
-        'GuardianWeekly',
-        tracking.ophanPageId,
-        tracking.referrerUrl,
-    );
+    const signInUrl =
+        'https://theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs';
 
     return (
         <>
             {showBanner ? (
-                <section className={banner} data-target="weekly-banner">
+                <section
+                    id="js-site-message--subscription-banner"
+                    className={banner}
+                    data-target="subscriptions-banner"
+                >
                     <div className={contentContainer}>
                         <div className={topLeftComponent}>
                             <h3 className={heading}>Read The Guardian in print</h3>
@@ -53,10 +53,16 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                 The Guardian Weekly, our essential world news magazine. Home
                                 delivery available wherever you are.
                             </p>
-                            <a className={linkStyle} href={subscriptionsUrl}>
+                            <a
+                                className={linkStyle}
+                                href={addTrackingParams(
+                                    'https://support.theguardian.com/subscribe/weekly',
+                                    tracking,
+                                )}
+                            >
                                 <div
-                                    id="js-site-message--weekly-banner__cta"
-                                    data-link-name="weekly-banner : cta"
+                                    id="js-site-message--subscription-banner__cta"
+                                    data-link-name="subscription-banner : cta"
                                     className={becomeASubscriberButton}
                                 >
                                     <span className={buttonTextDesktop}>
@@ -67,15 +73,15 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             </a>
                             <button
                                 className={notNowButton}
-                                id="js-site-message--weekly-banner__cta-dismiss"
-                                data-link-name="weekly-banner : not now"
+                                id="js-site-message--subscription-banner__cta-dismiss"
+                                data-link-name="subscription-banner : not now"
                                 onClick={(): void => closeBanner()}
                             >
                                 Not now
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a href={signInUrl} data-link-name="weekly-banner : sign in">
+                                <a href={signInUrl} data-link-name="subscription-banner : sign in">
                                     Sign in
                                 </a>{' '}
                                 to not see this again
@@ -91,7 +97,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                 <button
                                     onClick={(): void => closeBanner()}
                                     className={closeButton}
-                                    data-link-name="weekly-banner : close"
+                                    data-link-name="subscription-banner : close"
                                     aria-label="Close"
                                 >
                                     <SvgClose />

--- a/src/components/modules/banners/subscriptionsTracking.ts
+++ b/src/components/modules/banners/subscriptionsTracking.ts
@@ -1,0 +1,114 @@
+type SubscriptionsProductType = 'DigitalSubscription' | 'GuardianWeekly';
+
+type OphanComponentType =
+    | 'ACQUISITIONS_ENGAGEMENT_BANNER'
+    | 'ACQUISITIONS_THANK_YOU_EPIC'
+    | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
+
+type AcquisitionLinkParams = {
+    base: string;
+    componentType: OphanComponentType;
+    componentId: string;
+    campaignCode: string;
+    abTest?: {
+        name: string;
+        variant: string;
+    };
+};
+type AcquisitionData = {
+    componentType?: OphanComponentType;
+    componentId?: string;
+    campaignCode: string;
+    abTest?: {
+        name: string;
+        variant: string;
+    };
+};
+
+type Query = {
+    REFPVID: string;
+    INTCMP: string;
+    acquisitionData: string;
+};
+
+const COMPONENT_TYPE = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
+const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
+const CAMPAIGN_CODE = 'gdnwb_copts_banner_subscribe_SubscriptionBanner_digital';
+const GUARDIAN_WEEKLY_CAMPAIGN_CODE = 'gdnwb_copts_banner_subscribe_SubscriptionBanner_gWeekly';
+
+const constructURLQuery = (query: Query): string => {
+    return `REFPVID=${encodeURIComponent(query.REFPVID)}&INTCMP=${encodeURIComponent(
+        query.INTCMP,
+    )}&acquisitionData=${encodeURIComponent(query.acquisitionData)}`;
+};
+
+const addReferrerData = (acquisitionData: {}, ophanPageId: string, referrerUrl: string): {} => ({
+    ...acquisitionData,
+    referrerPageviewId: ophanPageId,
+    referrerUrl: referrerUrl,
+});
+
+const addTrackingCodesToUrl = (
+    { base, componentType, componentId, campaignCode, abTest }: AcquisitionLinkParams,
+    ophanPageId: string,
+    referrerUrl: string,
+): string => {
+    const acquisitionData = addReferrerData(
+        {
+            source: 'GUARDIAN_WEB',
+            componentId,
+            componentType,
+            campaignCode,
+            abTest,
+        },
+        ophanPageId,
+        referrerUrl,
+    );
+
+    const stringifiedAcquisitionData = JSON.stringify(acquisitionData);
+
+    const params = {
+        REFPVID: ophanPageId || 'not_found',
+        INTCMP: campaignCode,
+        acquisitionData: stringifiedAcquisitionData,
+    };
+
+    return `${base}${base.includes('?') ? '&' : '?'}${constructURLQuery(params)}`;
+};
+
+const guardianWeeklyBaseUrl = 'https://support.theguardian.com/subscribe/weekly';
+const digitalSubscriptionsBaseUrl = 'https://support.theguardian.com/subscribe/digital';
+
+export const getSubscriptionUrl = (
+    productType: SubscriptionsProductType,
+    ophanPageId: string,
+    referrerUrl: string,
+): string => {
+    const weeklySubsUrl = addTrackingCodesToUrl(
+        {
+            base: guardianWeeklyBaseUrl,
+            componentType: COMPONENT_TYPE,
+            componentId: OPHAN_EVENT_ID,
+            campaignCode: GUARDIAN_WEEKLY_CAMPAIGN_CODE,
+        },
+        ophanPageId,
+        referrerUrl,
+    );
+    const digiSubsUrl = addTrackingCodesToUrl(
+        {
+            base: digitalSubscriptionsBaseUrl,
+            componentType: COMPONENT_TYPE,
+            componentId: OPHAN_EVENT_ID,
+            campaignCode: CAMPAIGN_CODE,
+        },
+        ophanPageId,
+        referrerUrl,
+    );
+    return productType === 'GuardianWeekly' ? weeklySubsUrl : digiSubsUrl;
+};
+
+export const getSignInUrl = (productType: SubscriptionsProductType): string => {
+    return productType === 'GuardianWeekly'
+        ? 'https://theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs'
+        : 'https://theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
+};

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -13,7 +13,7 @@ import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
 import { countryCodeToCountryGroupId } from '../../lib/geolocation';
 
-type ReaderRevenueRegion =
+export type ReaderRevenueRegion =
     | 'united-kingdom'
     | 'united-states'
     | 'australia'


### PR DESCRIPTION
## What does this change?
We are adding tracking to the digital subscription and guardian weekly banners, as described in the [trello card for digital subscriptions](https://trello.com/c/WA4fipb1/3086-add-tracking-to-digital-subscriptions-banner-component) and the [trello card for guardian weekly](https://trello.com/c/dRNpnpbK/3087-add-tracking-to-guardian-weekly-banner-component).

## How to test
You can test this by running the code in storybook (with 'yarn storybook') and clicking on the 'Subscribe now' CTA and also the sign-in url. Since these are links, you can check where these clicks take you, noting however that the links are constructed from fakey fakey data in the stories for each banner.

// TODO: Add notes on how to test the not now and close buttons

## How can we measure success?
When these remote banners are switched on, tracking data keeps on flowing to GA and Ophan.

