### PR TITLE
Update epic image styles

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
@@ -66,9 +67,11 @@ const highlightStyles = css`
 `;
 
 const imageWrapperStyles = css`
-    margin: 10px -4px 12px;
-    height: 150px;
-    width: calc(100% + 8px);
+    margin: ${space[3]}px 0 ${space[2]}px;
+
+    ${from.tablet} {
+        margin: 10px 0;
+    }
 `;
 
 const imageStyles = css`


### PR DESCRIPTION
Essentially a mirror of [this PR](https://github.com/guardian/frontend/pull/22820). Removes the fixed height of images in epics. It is now up to the designer to pick an image with the preferred aspec ratio.

## Images
desktop:
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="653" alt="Screenshot 2020-07-22 at 10 39 31" src="https://user-images.githubusercontent.com/17720442/88161581-13126a00-cc08-11ea-9b8e-97e9ab0b0ae8.png">

tablet:
<img width="616" alt="Screenshot 2020-07-22 at 10 39 52" src="https://user-images.githubusercontent.com/17720442/88161604-186fb480-cc08-11ea-9606-56f77c8af5ae.png">

mobile:
<img width="389" alt="Screenshot 2020-07-22 at 10 40 09" src="https://user-images.githubusercontent.com/17720442/88161614-1c033b80-cc08-11ea-8105-a877213590ed.png">
