### PR TITLE
Update digital subscriptions banner copy

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -47,15 +47,12 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                     <div className={contentContainer}>
                         <div className={topLeftComponent}>
                             <h3 className={heading}>
-                                The world is changing by the minute.{' '}
-                                <br className={headLineBreak} />
-                                Keep up with a digital subscription.
+                                Open to all, <br className={headLineBreak} />
+                                supported by you
                             </h3>
                             <p className={paragraph}>
-                                Two Guardian apps, with you every day. <strong>The Daily</strong>,
-                                joining you in the morning to share politics, culture, food and
-                                opinion. <strong>Live</strong>, constantly by your side, keeping you
-                                connected with the outside world.
+                                Support open, independent journalism and enjoy two innovative apps
+                                and ad-free reading on theguardian.com
                             </p>
                             <a
                                 className={linkStyle}
@@ -94,11 +91,12 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             </div>
                         </div>
                         <div className={bottomRightComponent}>
-                            <img
-                                className={packShot}
-                                src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
-                                alt=""
-                            />
+                            <div className={packShot}>
+                                <img
+                                    src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
+                                    alt=""
+                                />
+                            </div>
                             <div className={iconPanel}>
                                 <button
                                     onClick={(): void => closeBanner()}

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -47,12 +47,13 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                     <div className={contentContainer}>
                         <div className={topLeftComponent}>
                             <h3 className={heading}>
-                                Open to all, <br className={headLineBreak} />
-                                supported by you
+                                Our reporting. <br className={headLineBreak} />
+                                Your pace.
                             </h3>
                             <p className={paragraph}>
-                                Support open, independent journalism and enjoy two innovative apps
-                                and ad-free reading on theguardian.com
+                                Tired of being always on? Our Daily edition comes to you just once a
+                                day. If a story breaks, you can still catch it with Premium access
+                                to our Live app. All with no ads. It&apos;s up to you.
                             </p>
                             <a
                                 className={linkStyle}

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -41,7 +41,8 @@ export const topLeftComponent = css`
         margin-left: ${space[3]}px;
     }
     ${from.tablet} {
-        width: 65%;
+        width: 60%;
+        padding-right: 0;
     }
 
     ${from.desktop} {
@@ -54,23 +55,26 @@ export const topLeftComponent = css`
 `;
 
 export const heading = css`
-    ${headline.small({ fontWeight: 'bold' })};
+    ${headline.xsmall({ fontWeight: 'bold' })};
     margin: 0;
     max-width: 100%;
 
-    @media (max-width: 740px) {
+    @media (min-width: 740px) {
         max-width: 90%;
     }
+    ${from.mobileLandscape} {
+        ${headline.small({ fontWeight: 'bold' })};
+    }
 
-    ${until.mobileLandscape} {
-        ${headline.xsmall({ fontWeight: 'bold' })};
+    ${from.tablet} {
+        max-width: 100%;
     }
 `;
 
 export const headLineBreak = css`
-    display: none;
-    @media (min-width: 1040px) {
-        display: block;
+    display: block;
+    ${from.phablet} {
+        display: none;
     }
 `;
 
@@ -79,12 +83,19 @@ export const paragraph = css`
     line-height: 135%;
     margin: ${space[2]}px 0 ${space[6]}px;
     max-width: 100%;
+
+    ${from.phablet} {
+        max-width: 80%;
+    }
+
     ${from.tablet} {
         max-width: 100%;
     }
+
     ${from.desktop} {
         font-size: 20px;
         margin: ${space[3]}px 0 ${space[9]}px;
+        max-width: 35rem;
     }
 `;
 
@@ -160,8 +171,9 @@ export const bottomRightComponent = css`
 
     ${from.tablet} {
         align-self: flex-end;
-        max-width: 35%;
-        margin-top: -200px;
+        max-width: 45%;
+        margin-top: -220px;
+        padding-right: ${space[4]}px;
     }
 
     ${from.desktop} {
@@ -181,19 +193,41 @@ export const bottomRightComponent = css`
 `;
 
 export const packShot = css`
-    max-width: 85%;
+    max-width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    margin-top: -20px;
+
+    img {
+        width: 90%;
+    }
+
+    ${from.mobileMedium} {
+        margin-top: -10px;
+    }
 
     ${from.phablet} {
         max-width: 100%;
     }
 
-    ${from.desktop} {
-        align-self: flex-end;
-        max-width: 80%;
+    ${from.tablet} {
+        img {
+            max-width: 125%;
+        }
+    }
+
+    ${from.tablet} {
+        img {
+            width: 100%;
+        }
     }
 
     ${from.leftCol} {
         max-width: 80%;
+        img {
+            width: 90%;
+        }
     }
 
     ${from.wide} {
@@ -203,13 +237,15 @@ export const packShot = css`
 `;
 
 export const iconPanel = css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-end;
-    height: 100%;
-    padding: ${space[4]}px 0;
-    margin: 0 ${space[4]}px;
+    ${from.desktop} {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-end;
+        height: 100%;
+        padding: ${space[4]}px 0;
+        margin-left: ${space[4]}px;
+    }
 `;
 
 export const logoContainer = css`
@@ -228,10 +264,9 @@ export const logoContainer = css`
 `;
 
 export const closeButton = css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
+    position: absolute;
+    top: 10px;
+    right: 10px;
     border: 1px solid ${neutral[100]};
     border-radius: 50%;
     outline: none;
@@ -241,8 +276,6 @@ export const closeButton = css`
     height: 35px;
 
     svg {
-        width: 25px;
-        height: 25px;
         fill: ${neutral[100]};
         transition: background-color 0.5s ease;
         border-radius: 50%;
@@ -252,10 +285,18 @@ export const closeButton = css`
         cursor: pointer;
         background-color: rgba(237, 237, 237, 0.5);
     }
+    ${from.desktop} {
+        position: relative;
+        top: 0;
+        right: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
 
-    ${until.desktop} {
-        position: absolute;
-        top: 10px;
-        right: 10px;
+        svg {
+            width: 25px;
+            height: 25px;
+        }
     }
 `;

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -95,7 +95,15 @@ export const paragraph = css`
     ${from.desktop} {
         font-size: 20px;
         margin: ${space[3]}px 0 ${space[9]}px;
-        max-width: 35rem;
+        max-width: 37rem;
+    }
+
+    ${from.leftCol} {
+        max-width: 30rem;
+    }
+
+    ${from.wide} {
+        max-width: 37rem;
     }
 `;
 

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css } from 'emotion';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
 import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 export const banner = css`


### PR DESCRIPTION
## What does this change?
The task was a simple copy update of the banner heading and first paragraph to match the banner that is currently live.

When I was comparing the banner to the designs, it was clear that the image sizing wasn't correct across all breakpoints and that it was a bit hard to manage, so I have refactored it to make it easier to tweak in future.

Link to [trello card](https://trello.com/c/7IpRdyye/3187-update-copy-in-digital-subscriptions-banner-on-contributions-service)

Link to [designs](https://www.figma.com/file/rvS52COKyRnNEOL91I10sn/Subscriptions-Banner---Template-designs?node-id=0%3A1) (NB: out of date copy)

## Images
![Screen Shot 2020-07-23 at 11 22 22](https://user-images.githubusercontent.com/16781258/88276604-3ce69200-ccd7-11ea-89d9-7641b5981147.png)

![Screen Shot 2020-07-23 at 11 23 11](https://user-images.githubusercontent.com/16781258/88276612-41ab4600-ccd7-11ea-94aa-d6d98a8e31c9.png)

![Screen Shot 2020-07-23 at 11 22 39](https://user-images.githubusercontent.com/16781258/88276625-453ecd00-ccd7-11ea-9e18-19c022e857c3.png)
