### PR TITLE
Remove ophanComponentId from tracking

### DIFF
--- a/src/components/modules/banners/ausMomentContributionsBanner/AusMomentContributionsBanner.stories.tsx
+++ b/src/components/modules/banners/ausMomentContributionsBanner/AusMomentContributionsBanner.stories.tsx
@@ -21,7 +21,6 @@ const tracking: BannerTracking = {
     campaignCode: 'AusMomentContributionsBanner_control',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-    ophanComponentId: 'ACQUISITIONS_ENGAGEMENT_BANNER', // TODO: Remove once cached components expire
 };
 
 const tickerSettings = {

--- a/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.stories.tsx
+++ b/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.stories.tsx
@@ -21,7 +21,6 @@ const tracking: BannerTracking = {
     campaignCode: 'AusMomentContributionsBanner_control',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-    ophanComponentId: 'ACQUISITIONS_ENGAGEMENT_BANNER', // TODO: Remove once cached components expire
 };
 
 const tickerSettings = {

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -20,7 +20,6 @@ const tracking: BannerTracking = {
     campaignCode: '',
     componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
     products: ['DIGITAL_SUBSCRIPTION'],
-    ophanComponentId: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER', // TODO: Remove once cached components expire
 };
 
 export const defaultStory = (): ReactElement => {

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -18,7 +18,6 @@ const tracking: BannerTracking = {
     campaignCode: '',
     componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
     products: ['PRINT_SUBSCRIPTION'],
-    ophanComponentId: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER', // TODO: Remove once cached components expire
 };
 
 export const defaultStory = (): ReactElement => {

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -39,7 +39,6 @@ export const defaultStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
@@ -85,7 +84,6 @@ export const backgroundImageStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
@@ -134,7 +132,6 @@ export const secondaryButtonStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
@@ -186,7 +183,6 @@ export const epicReminderStory = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
@@ -226,7 +222,6 @@ export const epicWithoutButtons = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
@@ -285,7 +280,6 @@ export const epicWithTicker = (): ReactElement => {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
-        ophanComponentId: testData.tracking.componentType, // TODO: Remove once cached components expire
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),

--- a/src/components/modules/epics/ContributionsEpic.testData.ts
+++ b/src/components/modules/epics/ContributionsEpic.testData.ts
@@ -48,7 +48,6 @@ const testTracking: EpicTestTracking = {
     abTestVariant: 'api',
     componentType: 'ACQUISITIONS_EPIC',
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-    ophanComponentId: 'ACQUISITIONS_EPIC', // TODO: Remove once cached components expire
 };
 
 const tracking: EpicTracking = {

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -14,7 +14,6 @@ export type EpicTestTracking = {
     campaignId: string;
     componentType: OphanComponentType;
     products: OphanProduct[];
-    ophanComponentId: OphanComponentType; // TODO: Remove once cached components expire
 };
 
 export type EpicTracking = EpicPageTracking & EpicTestTracking;

--- a/src/factories/tracking.ts
+++ b/src/factories/tracking.ts
@@ -20,7 +20,6 @@ export const testTracking = Factory.define<EpicTestTracking>(() => ({
     abTestVariant: 'api',
     componentType: 'ACQUISITIONS_EPIC',
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-    ophanComponentId: 'ACQUISITIONS_EPIC', // TODO: Remove once cached components expire
 }));
 
 export const tracking = Factory.define<EpicTracking>(({ factories }) => ({

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -58,7 +58,6 @@ describe('POST /epic', () => {
             campaignId: 'epic_2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
             componentType: 'ACQUISITIONS_EPIC',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            ophanComponentId: 'ACQUISITIONS_EPIC', // TODO: Remove once cached components expire
         });
     });
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -120,7 +120,6 @@ const buildEpicData = async (
         campaignId: `epic_${test.campaignId || test.name}`,
         componentType: 'ACQUISITIONS_EPIC',
         products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-        ophanComponentId: 'ACQUISITIONS_EPIC', // TODO: Remove once cached components expire
     };
 
     const props: EpicProps = {
@@ -162,7 +161,6 @@ const buildBannerData = async (
             campaignCode: buildBannerCampaignCode(test, variant),
             componentType: test.componentType,
             ...(test.products && { products: test.products }),
-            ophanComponentId: test.componentType, // TODO: Remove once cached components expire
         };
 
         const tickerSettings = variant.tickerSettings

--- a/src/tests/banners/DigitalSubscriptionsBannerTest.ts
+++ b/src/tests/banners/DigitalSubscriptionsBannerTest.ts
@@ -12,7 +12,7 @@ export const DigitalSubscriptionsBanner: BannerTest = {
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
         if (targeting.switches.remoteSubscriptionsBanner) {
             const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region === 'united-kingdom' || region === 'united-states';
+            return !(region === 'australia' || region === 'rest-of-world');
         }
         return false;
     },

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -23,7 +23,6 @@ export type BannerTestTracking = {
     campaignCode: string;
     componentType: OphanComponentType;
     products?: OphanProduct[];
-    ophanComponentId: OphanComponentType; // TODO: Remove once cached components expire
 };
 
 export type BannerPageTracking = {


### PR DESCRIPTION
## What does this change?

This PR is a tidy up following these PRs:

https://github.com/guardian/frontend/pull/22828
https://github.com/guardian/dotcom-rendering/pull/1741
https://github.com/guardian/contributions-service/pull/190

I'm removing `ophanComponentId` from the `tracking` object as this was temporarily left in to account for cached components that were expecting this in their `props`. 