### PR TITLE
Add Ophan Tracking to Subscriptions Banners 

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -28,11 +28,11 @@ import { addTrackingParams, createClickEventFromTracking } from '../../../../lib
 const subscriptionUrl = 'https://support.theguardian.com/subscribe/digital';
 const signInUrl =
     'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
-const bannerId = 'subscription-banner :';
-const ctaComponentId = `${bannerId} cta`;
-const notNowComponentId = `${bannerId} not now`;
-const closeComponentId = `${bannerId} close`;
-const signInComponentId = `${bannerId} sign in`;
+const bannerId = 'subscription-banner';
+const ctaComponentId = `${bannerId} : cta`;
+const notNowComponentId = `${bannerId} : not now`;
+const closeComponentId = `${bannerId} : close`;
+const signInComponentId = `${bannerId} : sign in`;
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     tracking,
@@ -40,10 +40,9 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
 
-    const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
-
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();
+        const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -63,7 +62,6 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
         evt.preventDefault();
         const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
-        console.log('componentClickEvent ---->', componentClickEvent);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
@@ -84,11 +82,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     return (
         <>
             {showBanner ? (
-                <section
-                    id="js-site-message--subscription-banner"
-                    className={banner}
-                    data-target="subscriptions-banner"
-                >
+                <section className={banner} data-target={bannerId}>
                     <div className={contentContainer}>
                         <div className={topLeftComponent}>
                             <h3 className={heading}>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -23,15 +23,60 @@ import {
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
+import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
+
+const subscriptionUrl = 'https://support.theguardian.com/subscribe/digital';
+const signInUrl =
+    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
+const bannerId = 'subscription-banner :';
+const ctaComponentId = `${bannerId} cta`;
+const notNowComponentId = `${bannerId} not now`;
+const closeComponentId = `${bannerId} close`;
+const signInComponentId = `${bannerId} sign in`;
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     tracking,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isSupporter,
+    submitComponentEvent,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
-    const closeBanner = (): void => {
+
+    const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
+
+    const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        window.location.href = subscriptionUrlWithTracking;
+    };
+
+    const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, signInComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        window.location.href = signInUrl;
+    };
+
+    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
+        console.log('componentClickEvent ---->', componentClickEvent);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        setShowBanner(false);
+        setSubscriptionsBannerClosedTimestamp();
+    };
+
+    const onNotNowClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, notNowComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
@@ -55,13 +100,9 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 day. If a story breaks, you can still catch it with Premium access
                                 to our Live app. All with no ads. It&apos;s up to you.
                             </p>
-                            <a
-                                className={linkStyle}
-                                href="https://support.theguardian.com/uk/subscribe"
-                            >
+                            <a className={linkStyle} onClick={onSubscribeClick}>
                                 <div
-                                    id="js-site-message--subscription-banner__cta"
-                                    data-link-name="subscription-banner : cta"
+                                    data-link-name={ctaComponentId}
                                     className={becomeASubscriberButton}
                                 >
                                     <span className={buttonTextDesktop}>
@@ -73,19 +114,14 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             </a>
                             <button
                                 className={notNowButton}
-                                id="js-site-message--subscription-banner__cta-dismiss"
-                                data-link-name="subscription-banner : not now"
-                                onClick={(): void => closeBanner()}
+                                data-link-name={notNowComponentId}
+                                onClick={onNotNowClick}
                             >
                                 Not now
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a
-                                    id="js-site-message--subscription-banner__sign-in"
-                                    href="https://support.theguardian.com/uk/subscribe"
-                                    data-link-name="subscription-banner : sign in"
-                                >
+                                <a data-link-name={signInComponentId} onClick={onSignInClick}>
                                     Sign in
                                 </a>{' '}
                                 to not see this again
@@ -100,10 +136,9 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             </div>
                             <div className={iconPanel}>
                                 <button
-                                    onClick={(): void => closeBanner()}
+                                    onClick={onCloseClick}
                                     className={closeButton}
-                                    id="js-site-message--subscription-banner__close-button"
-                                    data-link-name="subscription-banner : close"
+                                    data-link-name={closeComponentId}
                                     aria-label="Close"
                                 >
                                     <SvgClose />

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -21,15 +21,58 @@ import {
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
+import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
+
+const subscriptionUrl = 'https://support.theguardian.com/subscribe/weekly';
+const signInUrl =
+    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs';
+const bannerId = 'weekly-banner';
+const ctaComponentId = `${bannerId} : cta`;
+const notNowComponentId = `${bannerId} : not now`;
+const closeComponentId = `${bannerId} : close`;
+const signInComponentId = `${bannerId} : sign in`;
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     tracking,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isSupporter,
+    submitComponentEvent,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
-    const closeBanner = (): void => {
+
+    const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
+        const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        window.location.href = subscriptionUrlWithTracking;
+    };
+
+    const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, signInComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        window.location.href = signInUrl;
+    };
+
+    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        setShowBanner(false);
+        setSubscriptionsBannerClosedTimestamp();
+    };
+
+    const onNotNowClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+        evt.preventDefault();
+        const componentClickEvent = createClickEventFromTracking(tracking, notNowComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
         setShowBanner(false);
         setSubscriptionsBannerClosedTimestamp();
     };
@@ -37,7 +80,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     return (
         <>
             {showBanner ? (
-                <section className={banner} data-target="weekly-banner">
+                <section className={banner} data-target={bannerId}>
                     <div className={contentContainer}>
                         <div className={topLeftComponent}>
                             <h3 className={heading}>Read The Guardian in print</h3>
@@ -47,14 +90,11 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                 delivery available wherever you are.
                             </p>
                             <a
+                                data-link-name={ctaComponentId}
                                 className={linkStyle}
-                                href="https://support.theguardian.com/uk/subscribe"
+                                onClick={onSubscribeClick}
                             >
-                                <div
-                                    id="js-site-message--weekly-banner__cta"
-                                    data-link-name="weekly-banner : cta"
-                                    className={becomeASubscriberButton}
-                                >
+                                <div className={becomeASubscriberButton}>
                                     <span className={buttonTextDesktop}>
                                         Become a Guardian Weekly subscriber
                                     </span>
@@ -62,19 +102,15 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                 </div>
                             </a>
                             <button
+                                data-link-name={notNowComponentId}
                                 className={notNowButton}
-                                id="js-site-message--weekly-banner__cta-dismiss"
-                                data-link-name="weekly-banner : not now"
-                                onClick={(): void => closeBanner()}
+                                onClick={onNotNowClick}
                             >
                                 Not now
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a
-                                    href="https://www.theguardian.com"
-                                    data-link-name="weekly-banner : sign in"
-                                >
+                                <a data-link-name={signInComponentId} onClick={onSignInClick}>
                                     Sign in
                                 </a>{' '}
                                 to not see this again
@@ -88,9 +124,9 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             />
                             <div className={iconPanel}>
                                 <button
-                                    onClick={(): void => closeBanner()}
+                                    data-link-name={closeComponentId}
                                     className={closeButton}
-                                    data-link-name="weekly-banner : close"
+                                    onClick={onCloseClick}
                                     aria-label="Close"
                                 >
                                     <SvgClose />

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,7 +1,7 @@
 import { EpicTracking } from '../components/modules/epics/ContributionsEpicTypes';
-import { BannerTracking } from '../types/BannerTypes';
 import { Test, Variant } from '../lib/variants';
-import { BannerTest, BannerVariant } from '../types/BannerTypes';
+import { BannerTest, BannerVariant, BannerTracking } from '../types/BannerTypes';
+import { OphanComponentEvent } from '../types/OphanTypes';
 
 type LinkParams = {
     REFPVID: string;
@@ -48,3 +48,24 @@ export const buildCampaignCode = (test: Test, variant: Variant): string =>
 
 export const buildBannerCampaignCode = (test: BannerTest, variant: BannerVariant): string =>
     `${test.name}_${variant.name}`;
+
+export const createClickEventFromTracking = (
+    tracking: BannerTracking,
+    componentId: string,
+): OphanComponentEvent => {
+    const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+
+    return {
+        component: {
+            componentType,
+            products,
+            campaignCode,
+            id: componentId,
+        },
+        abTest: {
+            name: abTestName,
+            variant: abTestVariant,
+        },
+        action: 'CLICK',
+    };
+};


### PR DESCRIPTION
## What does this change?

This PR updates the `DigitalSubscriptionsBanner` and `GuardianWeeklyBanner` components in the following ways:

- 4 new click handlers have been setup in each banner: `onSubscribeClick`, `onCloseClick`, `onNotNowClick` and `onSignInClick`.
- Each click handler has been bound to the corresponding elements `onClick` event.
- Each click handler takes the `tracking` prop and using this creates a `componentClickEvent` of type `OphanComponentEvent`, using the newly introduced function `createClickEventFromTracking` in `tracking.ts`.
- The `componentClickEvent` is then passed to the prop `submitComponentEvent` introduced in https://github.com/guardian/contributions-service/pull/196, which triggers a call to `Ophan`.