### PR TITLE
Subscriptions banners: Fix layout on firefox

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -271,11 +271,11 @@ export const logoContainer = css`
         display: block;
         width: 100%;
         fill: ${neutral[100]};
-        min-width: 60px;
+        width: 70px;
     }
 
     ${from.leftCol} {
-        min-width: 80px;
+        width: 90px;
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -204,14 +204,14 @@ export const iconPanel = css`
 
 export const logoContainer = css`
     display: none;
+
     ${from.desktop} {
         display: block;
-        width: 100%;
         fill: ${neutral[100]};
-        min-width: 60px;
+        width: 70px;
     }
     ${from.leftCol} {
-        min-width: 80px;
+        min-width: 90px;
     }
 `;
 


### PR DESCRIPTION
## What does this change?
 
Whilst testing on firefox I found a layout issue with an oversized Guardian logo, this PR fixes that, I've tested across multiple browsers and this seems OK now.

**Before**

<img width="1308" alt="Screenshot 2020-07-27 at 17 21 41" src="https://user-images.githubusercontent.com/1590704/88566512-05a51780-d02e-11ea-8826-6d83b59756cd.png">

<img width="1308" alt="Screenshot 2020-07-27 at 17 13 55" src="https://user-images.githubusercontent.com/1590704/88566528-0c338f00-d02e-11ea-8c48-396c1a2d5b2f.png">

**After**

<img width="1308" alt="Screenshot 2020-07-27 at 17 20 47" src="https://user-images.githubusercontent.com/1590704/88566564-1e153200-d02e-11ea-89d4-89dce85af8a6.png">

<img width="1308" alt="Screenshot 2020-07-27 at 17 20 12" src="https://user-images.githubusercontent.com/1590704/88566595-27060380-d02e-11ea-807a-bc08e62c9a09.png">

