### PR TITLE
Use cursor:pointer on buttons in subs banners

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -20,6 +20,7 @@ import {
     notNowButton,
     becomeASubscriberButton,
     linkStyle,
+    signInLink,
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
@@ -115,7 +116,11 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a data-link-name={signInComponentId} onClick={onSignInClick}>
+                                <a
+                                    className={signInLink}
+                                    data-link-name={signInComponentId}
+                                    onClick={onSignInClick}
+                                >
                                     Sign in
                                 </a>{' '}
                                 to not see this again

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -122,6 +122,7 @@ export const linkStyle = css`
 `;
 
 export const becomeASubscriberButton = css`
+    cursor: pointer;
     display: inline-block;
     border-radius: 1.875rem;
     background-color: ${brandAlt[400]};
@@ -308,3 +309,7 @@ export const closeButton = css`
         right: 10px;
     }
 `;
+
+export const signInLink = `{
+    cursor: pointer;
+}`;

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -18,6 +18,7 @@ import {
     notNowButton,
     becomeASubscriberButton,
     linkStyle,
+    signInLink,
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setSubscriptionsBannerClosedTimestamp } from '../localStorage';
@@ -110,7 +111,11 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             </button>
                             <div className={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a data-link-name={signInComponentId} onClick={onSignInClick}>
+                                <a
+                                    className={signInLink}
+                                    data-link-name={signInComponentId}
+                                    onClick={onSignInClick}
+                                >
                                     Sign in
                                 </a>{' '}
                                 to not see this again

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -102,6 +102,7 @@ export const buttonTextMobileTablet = css`
 `;
 
 export const linkStyle = css`
+    cursor: pointer;
     text-decoration: none;
     :visited {
         color: ${text.primary};
@@ -244,3 +245,7 @@ export const closeButton = css`
         right: 10px;
     }
 `;
+
+export const signInLink = `{
+    cursor: pointer;
+}`;


### PR DESCRIPTION
## What does this change?

Whilst testing the banners I found the cursor wasn't the pointer on our CTA button and Sign In link on both the `DigitalSubscriptionsBanner` and the `GuardianWeeklyBanner`, this PR fixes that.