### PR TITLE
Fix cursor:pointer styles take 2

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -311,7 +311,5 @@ export const closeButton = css`
 `;
 
 export const signInLink = css`
-     {
-        cursor: pointer;
-    }
+    cursor: pointer;
 `;

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -247,7 +247,5 @@ export const closeButton = css`
 `;
 
 export const signInLink = css`
-     {
-        cursor: pointer;
-    }
+    cursor: pointer;
 `;


### PR DESCRIPTION
## What does this change?

The curly braces were unnecessary and prevented the build from completing on Teamcity, although validation passed on CI, and the build worked locally.