### PR TITLE
Switch from className to css

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -112,7 +112,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             <div css={siteMessage}>
                                 Already a subscriber?{' '}
                                 <a
-                                    className={signInLink}
+                                    css={signInLink}
                                     data-link-name={signInComponentId}
                                     onClick={onSignInClick}
                                 >

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -112,7 +112,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             <div css={siteMessage}>
                                 Already a subscriber?{' '}
                                 <a
-                                    className={signInLink}
+                                    css={signInLink}
                                     data-link-name={signInComponentId}
                                     onClick={onSignInClick}
                                 >


### PR DESCRIPTION
## What does this change?

Since the recent switch to `@emotion/core` className shouldn't be used anymore, we should use the `css` prop instead.