### PR TITLE
Restore preset-env

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,7 +1,15 @@
 {
     "presets": [
-      ["@babel/preset-react"],
-      "@emotion/babel-preset-css-prop"
+        ["@babel/preset-react"],
+        "@emotion/babel-preset-css-prop",
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "ie": "11"
+                }
+            }
+        ]
     ],
     "exclude": ["node_modules/**"]
-  }
+}


### PR DESCRIPTION
Restore preset-env for modules to fix experience for IE11 and other older browsers.
