### PR TITLE
Add epic reminder

### DIFF
--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -350,8 +350,8 @@ const defaultReminderFields: ReminderFields = {
 const defaultReminderCutoff = new Date('2020-09-14');
 
 const getDefaultReminderFields = (): ReminderFields | undefined => {
-  const now = new Date();
-  return now <= defaultReminderCutoff ? defaultReminderFields : undefined;
+    const now = new Date();
+    return now <= defaultReminderCutoff ? defaultReminderFields : undefined;
 };
 
 export const findTestAndVariant = (

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -341,6 +341,19 @@ export interface Result {
     debug?: Debug;
 }
 
+// Temporarily hard-coded while we decide on requirement
+const defaultReminderFields: ReminderFields = {
+    reminderCTA: 'Remind me in October',
+    reminderDate: '2020-10-14 00:00:00',
+    reminderDateAsString: 'October 2020',
+};
+const defaultReminderCutoff = new Date('2020-09-14');
+
+const getDefaultReminderFields = (): ReminderFields | undefined => {
+  const now = new Date();
+  return now <= defaultReminderCutoff ? defaultReminderFields : undefined;
+};
+
 export const findTestAndVariant = (
     tests: Test[],
     targeting: EpicTargeting,
@@ -393,8 +406,14 @@ export const findTestAndVariant = (
     );
 
     if (test) {
+        const variant = selectVariant(test, targeting.mvtId || 1);
+        const variantWithReminder: Variant = {
+            ...variant,
+            showReminderFields: variant.showReminderFields || getDefaultReminderFields(),
+        };
+
         return {
-            result: { test, variant: selectVariant(test, targeting.mvtId || 1) },
+            result: { test, variant: variantWithReminder },
             debug: includeDebug ? debug : undefined,
         };
     }


### PR DESCRIPTION
Frontend equivalent: https://github.com/guardian/frontend/pull/22908
We're still updating this manually for now.
Also, we're not currently showing any reminder in DCR because there is no default. This PR adds a default reminder, with a cut off.

Before clicking:
![Screen Shot 2020-08-19 at 11 00 45](https://user-images.githubusercontent.com/1513454/90623325-3a138a00-e20e-11ea-9a68-cfd74372d817.png)

After submitting:
![Screen Shot 2020-08-19 at 11 27 07](https://user-images.githubusercontent.com/1513454/90623832-f53c2300-e20e-11ea-9249-42112fdc0789.png)

Request:
![Screen Shot 2020-08-19 at 11 00 07](https://user-images.githubusercontent.com/1513454/90623321-397af380-e20e-11ea-8df0-8309b6a8ef44.png)
