### PR TITLE
Rename to support:dotcom-components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# docker build -t slot-service:latest .
-# docker run --init --rm -p 3030:3030 slot-service:latest
+# docker build -t dotcom-components:latest .
+# docker run --init --rm -p 3030:3030 dotcom-components:latest
 
 FROM node:12-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# docker build -t contributions-service:latest .
-# docker run --init --rm -p 3030:3030 contributions-service:latest
+# docker build -t slot-service:latest .
+# docker run --init --rm -p 3030:3030 slot-service:latest
 
 FROM node:12-alpine
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Support Slot Service
+# Support Dotcom Components
 
 ## Development
 
@@ -42,7 +42,7 @@ Use [nest](https://github.com/guardian/nest) for builds:
 The nest config file contains relevant configuration here.
 
 Secrets/config are also handled by Nest. Anything you place in parameter store
-with a `/slot-service/prod` (or `../code`) prefix will be passed as an
+with a `/dotcom-components/prod` (or `../code`) prefix will be passed as an
 environment variable to the app on startup. Note there are some naming
 transformations here - see the [nest secrets
 README](https://github.com/guardian/nest-secrets) for more info here.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Contributions Service
+# Support Slot Service
 
 ## Development
 
@@ -42,7 +42,7 @@ Use [nest](https://github.com/guardian/nest) for builds:
 The nest config file contains relevant configuration here.
 
 Secrets/config are also handled by Nest. Anything you place in parameter store
-with a `/contributions-service/prod` (or `../code`) prefix will be passed as an
+with a `/slot-service/prod` (or `../code`) prefix will be passed as an
 environment variable to the app on startup. Note there are some naming
 transformations here - see the [nest secrets
 README](https://github.com/guardian/nest-secrets) for more info here.

--- a/artifact.json
+++ b/artifact.json
@@ -1,5 +1,5 @@
 {
-    "projectName": "dotcom:contributions-service",
+    "projectName": "support:slot-service",
     "vcsURL": "https://github.com/guardian/contributions-service_",
     "actions": [
         {

--- a/artifact.json
+++ b/artifact.json
@@ -1,6 +1,6 @@
 {
-    "projectName": "support:slot-service",
-    "vcsURL": "https://github.com/guardian/contributions-service_",
+    "projectName": "support:dotcom-components",
+    "vcsURL": "https://github.com/guardian/support-dotcom-components_",
     "actions": [
         {
             "action": "lambda",

--- a/nest.json
+++ b/nest.json
@@ -1,8 +1,8 @@
 {
-    "app": "slot-service",
+    "app": "dotcom-components",
     "stack": "support",
-    "vcsURL": "https://github.com/guardian/contributions-service",
+    "vcsURL": "https://github.com/guardian/support-dotcom-components",
     "deploymentType": "alb-ec2-service",
     "artifactBucket": "membership-dist",
-    "cloudformationStackName": "slot-service"
+    "cloudformationStackName": "dotcom-components"
 }

--- a/nest.json
+++ b/nest.json
@@ -1,8 +1,8 @@
 {
-    "app": "contributions-service",
-    "stack": "frontend",
+    "app": "slot-service",
+    "stack": "support",
     "vcsURL": "https://github.com/guardian/contributions-service",
     "deploymentType": "alb-ec2-service",
-    "artifactBucket": "aws-frontend-artifacts",
-    "cloudformationStackName": "contributions-service-ec2"
+    "artifactBucket": "membership-dist",
+    "cloudformationStackName": "slot-service"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "slot-service",
+  "name": "dotcom-components",
   "version": "0.1.0",
-  "description": "Service to serve Reader Revenue components",
+  "description": "Service to serve Reader Revenue components to dotcom",
   "main": "dist/server.js",
-  "repository": "git@github.com:guardian/contributions-service.git",
+  "repository": "git@github.com:guardian/support-dotcom-components.git",
   "author": "The Guardian",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "contributions-service",
+  "name": "slot-service",
   "version": "0.1.0",
-  "description": "Service to serve contributions components",
+  "description": "Service to serve Reader Revenue components",
   "main": "dist/server.js",
   "repository": "git@github.com:guardian/contributions-service.git",
   "author": "The Guardian",


### PR DESCRIPTION
The Reader Revenue stream is taking ownership of this app.
Since its creation it has been expanded to serve subscriptions as well as contributions components.

Before:
stack: `frontend`
app: `contributions-service`

After:
stack: `support`
app: `dotcom-components`

The github repo will need to be renamed as well.